### PR TITLE
tp-link-eap225: switch to snapshot and ct driver

### DIFF
--- a/group_vars/model_tplink_eap225_outdoor_v1.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v1.yml
@@ -1,12 +1,8 @@
 ---
-imagebuilder: "https://downloads.openwrt.org/releases/21.02-SNAPSHOT/targets/ath79/generic/openwrt-imagebuilder-21.02-SNAPSHOT-ath79-generic.Linux-x86_64.tar.xz"
+imagebuilder: "https://downloads.openwrt.org/snapshots/targets/ath79/generic/openwrt-imagebuilder-ath79-generic.Linux-x86_64.tar.xz"
 feed_version: "1.2.0-snapshot"
 imagebuilder_disable_signature_check: true
 target: ath79/generic
-
-model__packages__to_merge:
-  - "-kmod-ath10k-ct -ath10k-firmware-qca9888-ct"
-  - "kmod-ath10k ath10k-firmware-qca9888"
 
 int_port: eth0
 


### PR DESCRIPTION
I prefer going to trunk and use the ct driver. The device seems unstable
and experiences crashes.