### PR TITLE
[WIP] corerouter: Enable IPv6 prefix delegation

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -63,8 +63,13 @@ config interface '{{ name }}'
   {% endif %}
   {% if role == 'corerouter' and ipv6_prefix is defined %}
     {% if 'ipv6_subprefix' in network %}
-      {% set subprefix = ipv6_prefix | ansible.utils.ipsubnet('64', network['ipv6_subprefix']) %}
-	option ip6addr '{{ subprefix | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}/{{ '128' if network['role'] == 'mesh' else '64' }}'
+      {% set subprefix = ipv6_prefix | ipsubnet('60', network['ipv6_subprefix']) %}
+      {% if name == 'dhcp' %}
+	option ip6addr '{{ subprefix | ipaddr(1) | ipaddr('address') }}/{{ '128' if network['role'] == 'mesh' else '64' }}'
+	option delegate '1'
+      {% else %}
+	option ip6addr '{{ subprefix | ipaddr(1) | ipaddr('address') }}/{{ '128' if network['role'] == 'mesh' else '64' }}'
+      {% endif %}
     {% endif %}
   {% endif %}
 

--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -37,6 +37,9 @@ config dhcp 'dhcp_{{ name }}'
 	option dhcpv6 'disabled'
     {% if network['role'] == 'dhcp' %}
 	option dhcpv4 'server'
+        {% if 'ipv6_subprefix' in network %}
+        option dhcpv6 'server'
+        {% endif %}
 	option force '1'
 	option leasetime '5m'
 	option start '2'


### PR DESCRIPTION

IPv6 prefix delegation (IPv6-PD) enables us to hand out prefixes of the /56
that is assigned to this router to downstream routers.
```
+----------+
| Freifunk |
|corerouter| Assigned IPv6 /56
+----------+
     |
     | IPv6-PD
    \ /
+----------+
|Downstream|
|  router  | Assigned IPv6 /60
+----------+
     |
     | DHCPv6
    \ /
+----------+
|  Client  | Assigned IPv6 /128
+----------+
```
option ip6addr / list ip6addr - OpenWRT seems to require 'list ip6addr' being used instead of 'option ip6addr' when IPv6-PD is in use.
option ip6prefix - IPv6 prefix routed here for use on other interfaces.
option ip6assign - Delegate a prefix of given length to this interface, not used in this patch
option ip6hint - Hint the subprefix-ID that should be delegated as hexadecimal number, not used in this patch.