### PR TITLE
uplink_gw: set split_horizon to false

### DIFF
--- a/roles/cfg_openwrt/templates/uplink_gateway/config/babeld.j2
+++ b/roles/cfg_openwrt/templates/uplink_gateway/config/babeld.j2
@@ -19,7 +19,7 @@ config interface
 config interface
 	option 'ifname' '{{ hostvars[gateway]['gre_tunnel_alias'] }}'
 	option 'rxcost' '{{ gre_metric }}'
-	option 'split_horizon' 'true'
+	option 'split_horizon' 'false'
 {% endfor %}
 
 config interface


### PR DESCRIPTION
    uplink_gw: set split_horizon to false
    
    With split-horizon some routes contain unnecessary hops via
    the gre-tunnels. Turn it off if the link is a gre-tunnel. Furthermore,
    gre-links are not slow and so no performance bottleneck is given.
    
    https://alioth-lists.debian.net/pipermail/babel-users/2014-June/001631.html