### PR TITLE
general.yml: change default contact nickname and mail to info@berlin.*

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -2,8 +2,8 @@
 zonename: 'Europe/Berlin'
 timezone: 'CET-1CEST,M3.5.0,M10.5.0/3'
 
-contact_nickname: 'please_add_operator_name'
-contact_email: 'please_add_operators_contact'
+contact_nickname: 'Freifunk Berlin Maintenance Team'
+contact_email: 'info@berlin.freifunk.net'
 
 
 dns_servers:

--- a/roles/cfg_openwrt/templates/common/config/freifunk.j2
+++ b/roles/cfg_openwrt/templates/common/config/freifunk.j2
@@ -2,9 +2,7 @@ config public 'contact'
 {% if contact_name is defined %}
 	option name '{{ contact_name }}'
 {% endif %}
-{% if contact_name is not defined or contact_nickname != 'please_add_operator_name' %}
 	option nickname '{{ contact_nickname }}'
-{% endif %}
 	option mail '{{ contact_email }}'
 	option location '{{ location_nice }}'
 


### PR DESCRIPTION
As discussed earlier I changed the standard contact information.