### PR TITLE
templates: fix dsa sysupgrade

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/system.j2
+++ b/roles/cfg_openwrt/templates/common/config/system.j2
@@ -11,7 +11,9 @@ config system
 	option altitude '60.000000000000000'
 	option location '{{ location_nice|default(location) }}'
 {% endif %}
-
+{% if dsa_ports is defined %}
+	option compat_version '1.1'
+{% endif %}
 
 config timeserver 'ntp'
         option enabled '1'


### PR DESCRIPTION
Fixes errors in the form of:
"The device is supported, but the config is incompatible to the new image ($devicecompat->$imagecompat). Please upgrade without keeping config (sysupgrade -n)."

The compat_version is missing so DSA targets are interpreted as 1.0
although they are 1.1.