### PR TITLE
treewide: prepare meshing via wireguard tunnel

### DIFF
--- a/roles/cfg_openwrt/tasks/main.yml
+++ b/roles/cfg_openwrt/tasks/main.yml
@@ -37,7 +37,7 @@
     file: render_subdir.yml
     apply:
       tags: always
-  loop: ['/', '/config','/dropbear', '/collectd/conf.d', '/init.d', '/crontabs', '/conntrackd']
+  loop: ['/', '/config','/dropbear', '/collectd/conf.d', '/init.d', '/crontabs', '/conntrackd', '/iproute2']
   loop_control:
     loop_var: subdir
   tags: always

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -61,6 +61,13 @@ config interface '{{ name }}'
     {% endif %}
   {% endif %}
 
+  {%- if (role == 'corerouter' and network['role'] == 'uplink') -%}
+config interface '{{ name }}'
+	option proto 'static'
+	option device '{{ ('br-' + name) if bridge_needed else port }}'
+  {% endif %}
+
+
   {% if port_needed and bridge_needed %}
 config device
 	option name 'br-{{ name }}'
@@ -76,5 +83,22 @@ config device
 config device '{{ i }}_dev'
 	option name '{{ i }}'
 	option macaddr '{{ mac_override[i] }}'
+
+{% endfor %}
+
+{% for network in networks | selectattr('role','equalto','dhcp') %}
+config rule
+	option in     '{{ network['name'] if 'name' in network else network['role'] }}'
+	option dest   '0.0.0.0/0'
+	option lookup '{{ olsr_table }}'
+
+config rule
+	option in     '{{ network['name'] if 'name' in network else network['role'] }}'
+	option dest   '0.0.0.0/0'
+	option lookup '{{ babel_table }}'
+
+config rule
+	option in     '{{ network['name'] if 'name' in network else network['role'] }}'
+	option action 'prohibit'
 
 {% endfor %}

--- a/roles/cfg_openwrt/templates/corerouter/config/babeld.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/babeld.j2
@@ -25,3 +25,9 @@ config filter
 	option 'local'  'true'
 	option 'action' 'deny'
 {% endif %}
+
+{% if babel_table is defined ||  %}
+config filter
+	option 'type'	'install'
+	option 'action'	'table {{ babel_table }}'
+{% endif %}

--- a/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
@@ -40,6 +40,11 @@ config olsrd
 	option OlsrPort '698'
 	option Willingness '3'
 	option TosValue '16'
+{% if olsr_table is defined %}
+	option RtTable '{{ olsr_table }}'
+	option RtTableDefault '{{ olsr_table }}'
+	option RtTableTunnel '{{ olsr_table }}'
+{% endif %}
 
 config InterfaceDefaults
 	option MidValidityTime '500.0'
@@ -62,7 +67,7 @@ config Interface
   {% endfor %}
 
 {% endfor %}
-{% for network in networks | rejectattr('role', 'equalto', 'ext') | selectattr('prefix') %}
+{% for network in networks | rejectattr('role', 'equalto', 'ext') | rejectattr('role', 'equalto', 'uplink') | selectattr('prefix') %}
   {% if network['prefix'] | ipaddr('prefix') < 32 %}
 
 # Network: {{ network['name'] if 'name' in network else network['role'] }}

--- a/roles/cfg_openwrt/templates/corerouter/iproute2/rt_tables.j2
+++ b/roles/cfg_openwrt/templates/corerouter/iproute2/rt_tables.j2
@@ -1,0 +1,7 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+{% if olsr_table is defined %}
+echo {{ olsr_table }} olsr_table >> /etc/iproute2/rt_tables
+{% endif %}
+{% if babel_table is defined %}
+echo {{ babel_table }} babel >> /etc/iproute2/rt_tables
+{% endif %}


### PR DESCRIPTION
- add dhcp interface role called uplink
- add ability to specify routing tables for mesh links
- create routing tables
- set policies