### PR TITLE
template: Throw error if network name is too long

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -99,6 +99,7 @@ config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
       {% if 'mcast_rate' in iface %}
 	option mcast_rate '{{ iface['mcast_rate'] }}'
       {% endif %}
+        {{ ('Mesh name ok' if mesh_net['name'] | length < 15) | mandatory('Network name is longer than 15 characters') }}
 	option network '{{ mesh_net['name'] }}'
     {% endif %}
     {% endif %}


### PR DESCRIPTION
Due to kernel limitations, the maximum length for a network is 15
characters.

Cause a build failure if the network name is longer than 15 characters,
and output a helpful error message.