### PR TITLE
gub37: Lower link quality multiplier for mesh links

### DIFF
--- a/group_vars/location_gub37/networks.yml
+++ b/group_vars/location_gub37/networks.yml
@@ -18,6 +18,7 @@ networks:
     mesh_ap: gub37-core
     mesh_radio: 11g_standard
     mesh_iface: mesh
+    mesh_metric_lqm: ['default 0.3']
 
   - vid: 21
     role: mesh
@@ -27,6 +28,7 @@ networks:
     mesh_ap: gub37-core
     mesh_radio: 11a_standard
     mesh_iface: mesh
+    mesh_metric_lqm: ['default 0.3']
 
   - vid: 22
     role: mesh
@@ -36,6 +38,7 @@ networks:
     mesh_ap: gub37-hof-n-5
     mesh_radio: 11a_standard
     mesh_iface: mesh
+    mesh_metric_lqm: ['default 0.3']
 
   - vid: 40
     role: dhcp


### PR DESCRIPTION
This is necessary in order to prevent using mesh links for routing when
backbone links are available.