### PR TITLE
template: Fix bad syntax from length check

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -99,8 +99,7 @@ config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
       {% if 'mcast_rate' in iface %}
 	option mcast_rate '{{ iface['mcast_rate'] }}'
       {% endif %}
-        {{ ('Mesh name ok' if mesh_net['name'] | length < 15) | mandatory('Network name is longer than 15 characters') }}
-	option network '{{ mesh_net['name'] }}'
+	option network '{{ (mesh_net['name'] if mesh_net['name'] | length < 15) | mandatory('Network name is longer than 15 characters') }}'
     {% endif %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
This commit fixes an issue introduced when https://github.com/freifunk-berlin/bbb-configs/commit/2e432f6286c6be7ed287b92a977d85a437f095d5 added length checking.

```
config wifi-iface 'radio0_if2'
	option device 'radio0'
	option ifname 'wlan5-mesh'
	option mode 'mesh'
	option mesh_id 'Mesh-Freifunk-Berlin'
	option mesh_fwding '0'
	option mcast_rate '12000'
        Mesh name ok
	option network 'mesh_11s_no5'
```

'Mesh name ok' is not mean to be in the above snippet, and causes a parsing issue. 

This commit fixes this syntax error, while keeping the length checking.