### PR TITLE
gub37: Switch out Hof Nord 5GHz radio

### DIFF
--- a/host_vars/gub37-hof-n-5/base.yml
+++ b/host_vars/gub37-hof-n-5/base.yml
@@ -2,6 +2,4 @@
 
 location: gub37
 role: ap
-model: "ubnt_nanostation_loco_m5_xw"
-
-poe_on: []
+model: "mikrotik_sxtsq-5-ac"


### PR DESCRIPTION
Switch to a Mikrotik LHG 5 AC radio, which runs the same firmware as SXTsq 5 AC.