### PR TITLE
[WIP] corerouter: set differentiated services (DSCP) for OLSR

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/nftables.d/21-olsr-dsp.nft.j2
+++ b/roles/cfg_openwrt/templates/corerouter/nftables.d/21-olsr-dsp.nft.j2
@@ -1,0 +1,7 @@
+{% if (networks | selectattr('tunnel_wan_ip', 'defined') | count > 0) and (openwrt_version == 'snapshot') %}
+chain dscp_olsr {
+    type filter hook output priority -1; policy accept;
+    udp dport 698
+    ip dscp set ef
+}
+{% endif %}


### PR DESCRIPTION
Set OLSR packates to Expedited Forwarding (EF) class. EF traffic is
strictly prioritized.