### PR TITLE
role_ap: fix firewall4 is installed

### DIFF
--- a/group_vars/role_ap/imageprofile.yml
+++ b/group_vars/role_ap/imageprofile.yml
@@ -1,6 +1,7 @@
 ---
 role_ap__packages__to_merge:
   - "-firewall"
+  - "-firewall4"
 
 role_ap__disabled_services__to_merge:
   - "dnsmasq"


### PR DESCRIPTION
With commit 58784281e939 ("corerouter: switch to nftables for mss
clamping") firewall4 was not longer removed from the whole package list.

The snapshot APs have firewall4 included by default and so we need to
explicitly remove it from their package list.