### PR TITLE
role_ap: fix remove of firewall

### DIFF
--- a/group_vars/role_ap/imageprofile.yml
+++ b/group_vars/role_ap/imageprofile.yml
@@ -2,6 +2,7 @@
 role_ap__packages__to_merge:
   - "-firewall"
   - "-firewall4"
+  - "-luci-app-firewall"
 
 role_ap__disabled_services__to_merge:
   - "dnsmasq"


### PR DESCRIPTION
Firewall is still included in the ap-images because it is a depdency of
luci-app-firewall. Remove also the luci app.