### PR TITLE
inventory: speed it up significantly

### DIFF
--- a/inventory/base_inventory
+++ b/inventory/base_inventory
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
-HOSTS=$(for i in host_vars/*; do echo -e "$i\c" | awk -F'/' '{print "\""$2"\","}'; done)
-HOSTS=$(echo $HOSTS | sed 's/\(.*\),/\1 /')
-cat <<EOF
+case "$1" in
+--host)
+    echo '{}'
+    ;;
+--list)
+    HOSTS=$(for i in host_vars/*; do echo -e "$i\c" | awk -F'/' '{print "\""$2"\","}'; done)
+    HOSTS=$(echo $HOSTS | sed 's/\(.*\),/\1 /')
+    cat <<EOF
 {
     "all": {
 	"hosts": [ $HOSTS ]
     }
 }
 EOF
-
+    ;;
+esac


### PR DESCRIPTION
The inventory script was printing the host list unconditionally,
providing unneccessary metric tons of data to the gatherer.

We now properly implement the --list and --host options mandated by Ansible.
This gets us from >30s down to ~3s on my personal machine.

```sh
# before
> time ansible-inventory --list >/dev/null
real 0m36,480s user 0m33,413s sys 0m9,379s

# after
> time ansible-inventory --list >/dev/null
real 0m2,633s user 0m2,286s sys 0m0,420s
```

See https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#inventory-script-conventions