### PR TITLE
workflows: build dummy hosts if no host changed

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -31,6 +31,9 @@ jobs:
           echo "Building for $CHANGED_HOSTS"
           echo "CHANGED_HOSTS=$CHANGED_HOSTS" >> $GITHUB_ENV
           CHANGED_LOCATIONS=$(git diff --diff-filter=d --name-only origin/$BRANCH | grep location_ | awk -F/ '{print $2}' | awk -F_ '{print $2"*"}' | sed -z 's/\n/,/g')
+          if [ -z "${CHANGED_LOCATIONS}" ]; then
+            CHANGED_LOCATIONS="sama-core,sama-nord-nf-5ghz,ohlauer-gw"
+          fi
           echo "Building for $CHANGED_LOCATIONS"
           echo "CHANGED_LOCATIONS=$CHANGED_LOCATIONS" >> $GITHUB_ENV
 


### PR DESCRIPTION
If changes are applied not affecting any hosts or locations, all hosts were built. However, github was frequently aborting that run.Instead of building all hosts, we only build an ap, core and a gateway.