### PR TITLE
Gruni73 channels

### DIFF
--- a/group_vars/location_gruni73/networks.yml
+++ b/group_vars/location_gruni73/networks.yml
@@ -101,4 +101,4 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__channel_assignments_11a_standard__to_merge:
   gruni73-nf-w-5ghz: 36-20
-  gruni73-nf-so-5ghz: 40-20
+  gruni73-nf-so-5ghz: 50-20

--- a/group_vars/location_gruni73/networks.yml
+++ b/group_vars/location_gruni73/networks.yml
@@ -96,7 +96,7 @@ networks:
 
 
 location__channel_assignments_11g_standard__to_merge:
-  gruni73-nf-sw-2ghz: 6-20
+  gruni73-nf-sw-2ghz: 1-20
   gruni73-nf-o-2ghz: 13-20
 
 location__channel_assignments_11a_standard__to_merge:


### PR DESCRIPTION
Dodge busy 2ghz channel. Avoid 5ghz channels that overlap with uplink radios.