### PR TITLE
Switch ar40xx devices to snapshot

### DIFF
--- a/group_vars/model_avm_fritzbox_4040.yml
+++ b/group_vars/model_avm_fritzbox_4040.yml
@@ -1,4 +1,5 @@
 ---
+openwrt_version: snapshot
 target: ipq40xx/generic
 
 model__packages__to_merge:

--- a/group_vars/model_avm_fritzbox_7530.yml
+++ b/group_vars/model_avm_fritzbox_7530.yml
@@ -1,4 +1,5 @@
 ---
+openwrt_version: snapshot
 target: ipq40xx/generic
 
 model__packages__to_merge:

--- a/group_vars/model_mikrotik_sxtsq_5_ac.yml
+++ b/group_vars/model_mikrotik_sxtsq_5_ac.yml
@@ -1,4 +1,5 @@
 ---
+openwrt_version: snapshot
 target: ipq40xx/mikrotik
 
 model__packages__to_merge:


### PR DESCRIPTION
In order to use the fixed ar40xx driver, switch to OpenWRT Snapshot.

https://github.com/openwrt/openwrt/commit/e9431a8335658fd8bcb1c01b3c7e59bf0401196d