### PR TITLE
use comments from yml file for generation of authorized_keys

### DIFF
--- a/roles/cfg_openwrt/templates/common/dropbear/authorized_keys.j2
+++ b/roles/cfg_openwrt/templates/common/dropbear/authorized_keys.j2
@@ -1,5 +1,4 @@
 {% for i in ssh_keys %}
-# {{ i['comment'] }}
-{{ i['key']}}
+{{ i['key'].split()[0] }} {{ i['key'].split()[1] }} {{ i['comment'] }}
 {% endfor %}
 


### PR DESCRIPTION
This replaces the comment from the original ssh-key with the comment of the yml file, which is the name of the user. This labels keys without a comment with a proper username so it can easily be identified on the router and removes useless information like machine names from the file. The original comment can still be kept in the git repository, where it might be useful to the owner of the key to identify his key.