### PR TITLE
corerouter/gateway: enable ntp server

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/system.j2
+++ b/roles/cfg_openwrt/templates/common/config/system.j2
@@ -17,7 +17,7 @@ config system
 
 config timeserver 'ntp'
         option enabled '1'
-        option enable_server '0'
+        option enable_server '{{ (role == 'corerouter' or role  == 'uplink_gateway') | int }}'
 {% for ntp_server in ntp_servers %}
         list server '{{ ntp_server }}'
 {% endfor %}


### PR DESCRIPTION
On some sites the airos devices are configured to get the time from
the core router. Enable the server on core-router and uplink-gateway.