### PR TITLE
corerouter: add domain search option for olsr domains

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -27,6 +27,7 @@ config dhcp 'dhcp_{{ name }}'
 	option leasetime '5m'
 	option start '2'
 	option limit '{{ network['prefix'] | ipaddr('size') -3 }}'
+	list dhcp_option '119,olsr'
     {% else %}
 	option dhcpv4 'disabled'
     {% endif %}


### PR DESCRIPTION
Let the dhcp servers pass name service configuration to DHCP clients
about olsr domains. This will result in:

search olsr
nameserver [IP]