### PR TITLE
Gateways: add ssh-key for dpaufler

### DIFF
--- a/group_vars/role_uplink_gateway/ssh-key.yml
+++ b/group_vars/role_uplink_gateway/ssh-key.yml
@@ -1,0 +1,5 @@
+---
+role__ssh_keys__to_merge:
+  - comment: dpaufler
+    key: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAuMu0TKkVut4KeUsq3n3XDSBw/SgxB4TGsZ8bruRjm8AX4vvrLyZpFcE0MAljqJRhbpRKuMUBFZazPbwVoplGnw49KkTA+KDLVFQQNXD13K0kKcLtP5KuJxiwjLyRShGBgnccItjYqkcPwC+C1jqWdqm5WiwmcQmd9bD+4MhzrgN9g6BLpYiQyDgMoBPgY0AaAVYbuTOdYHTLHOzGmH3cBFGWiwXn8jDWD8uoJOQFQXHpgpKhJRKrE9fXLu3IMSv85YRewiuXlwAiS1j6ok9SpEnUehA3xCGSjTItw9AhXEfXjAmIL6uEymL5KPyygYxphZb8In2v/dqU1qxKhqJv4Q== Daniel Paufler <dpaufler@leo34.net>
+...


### PR DESCRIPTION
The gateways which are sponsored by the förderverein schould be
accessible by it.

Signed-off-by: Martin Hübner <martin.hubner@web.de>