### PR TITLE
group_vars/role_uplink_gateway/general.yml: add scherer8-wetter inbound filter

### DIFF
--- a/group_vars/role_uplink_gateway/general.yml
+++ b/group_vars/role_uplink_gateway/general.yml
@@ -85,6 +85,10 @@ inbound_allow:
     proto: tcp
     src: 2a04:d480:2c02:b::/64
     dst_port: 9100
+  - name: 'scherer8-wetter'
+    dst: '2001:bf7:750:2e00::10'
+    proto: tcp
+    dst_port: 80
 #  - name: Rule Description (mandatory)
 #    dst: Destination IP (mandatory)
 #    src: Source IP


### PR DESCRIPTION
add IP 2001:bf7:750:2e00::10 on port 80 to inbound filter to allow
global access to scherer8-wetter.olsr

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>