### PR TITLE
all: remove plugins that scrape mac addresses 

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -40,13 +40,14 @@ all_luci_base__packages__to_merge:
 all_prompoc__packages__to_merge:
   - curl
   - prometheus-node-exporter-lua
-  - prometheus-node-exporter-lua-hostapd_stations
-  - prometheus-node-exporter-lua-hostapd_ubus_stations
   - prometheus-node-exporter-lua-netstat
   - prometheus-node-exporter-lua-openwrt
   - prometheus-node-exporter-lua-snmp6
   - prometheus-node-exporter-lua-wifi
-  - prometheus-node-exporter-lua-wifi_stations
+  # Remove them due to privacy implications
+  # - prometheus-node-exporter-lua-hostapd_stations
+  # - prometheus-node-exporter-lua-hostapd_ubus_stations
+  # - prometheus-node-exporter-lua-wifi_stations
 
 all_disabled_services__to_merge:
   - "olsrd6"


### PR DESCRIPTION
The plugin scrape the mac addresses of client stations. Remove them.

I am sure there is a way to disable the scraping of mac addresses. However, that needs additional coding. Remove them until it is fixed.