### PR TITLE
babel: rework metrik; use filter, leave rxcost vanilla

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/babeld.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/babeld.j2
@@ -8,11 +8,17 @@ config general
 	option 'ubus_bindings' 'true'
 
   {% for network in networks | selectattr('role', 'equalto', 'mesh') | selectattr('ipv6_subprefix') %}
+    {% set _ifname = network['name'] if 'name' in network else network['role'] %}
 config interface
-	option 'ifname' '{{ network['name'] if 'name' in network else network['role'] }}'
-	option 'rxcost' '{{ network['mesh_metric'] if 'mesh_metric' in network else '512' }}'
+	option 'ifname' '{{ _ifname }}'
 	option 'split_horizon' '{{ (network['ptp'] if 'ptp' in network else false ) | string | lower }}'
-	option 'link_quality' '{{ network.get('link_quality_based_metric', true) | string }}'
+	option 'link_quality' '{{ network.get('link_quality_based_metric', true) | string | lower }}'
+	option 'rxcost' '{{ '256' if network.get('link_quality_based_metric', true) else '96' }}'
+
+config filter
+	option 'type' 'in'
+	option 'if' '{{ _ifname }}'
+	option 'action' 'metric {{ network.get('mesh_metric', 512) }}'
 
   {% endfor -%}
 

--- a/roles/cfg_openwrt/templates/uplink_gateway/config/babeld.j2
+++ b/roles/cfg_openwrt/templates/uplink_gateway/config/babeld.j2
@@ -11,9 +11,14 @@ config interface
 {% for interface in mesh_links|default([]) %}
 config interface
 	option 'ifname' '{{ interface['name'] }}'
-	option 'rxcost' '{{ interface['metric'] }}'
+	option 'rxcost' '{{ '256' if interface.get('link_quality_based_metric', true) else '96' }}'
 	option 'split_horizon' '{{ (interface['ptp'] if 'ptp' in interface else false ) | string | lower }}'
 	option 'link_quality' '{{ interface.get('link_quality_based_metric', true) | string | lower }}'
+
+config filter
+       option 'type' 'in'
+       option 'if' '{{ interface['name'] }}'
+       option 'action' 'metric {{ interface.get('mesh_metric', 512) }}'
 
 {% endfor %}
 


### PR DESCRIPTION
With the now enabled link quality estimation, we should leave the rxcost untouched for now, as this is the base which will be multiplied if packetloss is detected. 

Our metric is now explicitly added to the calculated metric.