### PR TITLE
linsys-e8450: fix building images

### DIFF
--- a/group_vars/model_linksys_e8450_ubi.yml
+++ b/group_vars/model_linksys_e8450_ubi.yml
@@ -1,5 +1,5 @@
 ---
-openwrt_version: 22.03.0-rc1
+openwrt_version: 22.03-SNAPSHOT
 feed_version: snapshot
 target: mediatek/mt7622
 


### PR DESCRIPTION
OpenWrt moved wolfssl from packages to main repository. However, the
package feed is now invalid. Go to openwrt-snapshot again.