### PR TITLE
segen: more accurate geo position

### DIFF
--- a/group_vars/location_segen/owm.yml
+++ b/group_vars/location_segen/owm.yml
@@ -1,4 +1,4 @@
 ---
 location_nice: Segenskirche
-latitude: 52.536022
-longitude: 13.412086
+latitude: 52.53604
+longitude: 13.41198


### PR DESCRIPTION
The current position is inaccurate and hopglass shows the position marker on the street. This fixes the position so it points to the center of the tower of the church.