### PR TITLE
add yamllint as a standalone linter with its own config

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -4,7 +4,6 @@ exclude_paths:
   - .git
 
 warn_list:
-  - yaml
   - literal-compare
   - no-changed-when
   - command-instead-of-shell
@@ -13,3 +12,4 @@ warn_list:
 skip_list:
   - fqcn-builtins
   - experimental
+  - yaml

--- a/.config/yaml-lint.yml
+++ b/.config/yaml-lint.yml
@@ -1,0 +1,15 @@
+---
+# This extends the default yaml-lint conf by adjusting some options.
+
+extends: default
+
+rules:
+  comments:
+    level: error
+  comments-indentation:
+    level: error
+  document-start:
+    level: error
+  line-length:
+    max: 2048
+    level: warning

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,3 +1,4 @@
+---
 name: Ansible Lint
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,3 +1,4 @@
+---
 name: Test Build
 
 on:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,12 @@
+---
+name: Yaml Lint
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Yaml Files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .config/yaml-lint.yml

--- a/FAQ.md
+++ b/FAQ.md
@@ -61,10 +61,11 @@ Have a look at the [Developers Guide](DEVELOPER.md) for more information.
 
 ## What is required to send in a pull request?
 
-Make sure to test your addition with ansible-lint before sending a pull request by using:
+Make sure to test your addition with yamllint and ansible-lint before sending a pull request by using:
 
 ```sh
-ansible-lint
+yamllint -d .config/yaml-lint.yml .
+ansible-lint -c .config/ansible-lint.yml
 ```
 
 ## How can I mass deploy in the Freifunk Network

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ansible_merge_vars >= 5.0.0
 jmespath >= 0.10.0
 netaddr >= 0.8.0
 ansible-lint >= 6.3.0
+yamllint >= 1.26.3


### PR DESCRIPTION
ansible-lint uses yamllint to lint yaml files but does not allow a custom config for yamllint e.g. to configure or ignore line length. this commit fixes this by adding yamllint as a standalone linter with its own config