### PR TITLE
config: disable truthy in config

### DIFF
--- a/.config/yaml-lint.yml
+++ b/.config/yaml-lint.yml
@@ -13,3 +13,4 @@ rules:
   line-length:
     max: 2048
     level: warning
+  truthy: disable


### PR DESCRIPTION
Fixes unnecessary warnings:
  ./.github/workflows/testbuild.yml
    4:1       warning  truthy value should be one of [false, true]  (truthy)