### PR TITLE
mediatek: belkin rt3200: avoid the low voltage leading to a hang on r…

### DIFF
--- a/group_vars/model_linksys_e8450_ubi.yml
+++ b/group_vars/model_linksys_e8450_ubi.yml
@@ -19,3 +19,7 @@ wireless_devices:
     hwmode: 11a
     path: 1a143000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0
     ifname_hint: wlan5
+
+sysfs_overrides:
+  - path: /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq
+    value: 437500


### PR DESCRIPTION
…ebooting

As described here the rt3200 can hang on rebooting:
- https://github.com/openwrt/openwrt/pull/5025
- https://github.com/openwrt/openwrt/pull/5025/files
- https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/1490