### PR TITLE
Revert "mediatek: belkin rt3200: avoid the low voltage leading to a h…

### DIFF
--- a/group_vars/model_linksys_e8450_ubi.yml
+++ b/group_vars/model_linksys_e8450_ubi.yml
@@ -19,7 +19,3 @@ wireless_devices:
     hwmode: 11a
     path: 1a143000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0
     ifname_hint: wlan5
-
-sysfs_overrides:
-  - path: /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq
-    value: 437500


### PR DESCRIPTION
…ang on rebooting"

This reverts commit abc3b13da526f8caccdd70cbe0b7b854e741ed08.

No longer needed due to fix ("mt7622: remove 300 MHz from dts"):
https://github.com/openwrt/openwrt/commit/8ccd657629a086d3fb6520a6b91712b1ed0810b7