### PR TITLE
corerouter: add lldpd

### DIFF
--- a/group_vars/role_corerouter/imageprofile.yml
+++ b/group_vars/role_corerouter/imageprofile.yml
@@ -1,6 +1,7 @@
 ---
 role_corerouter__packages__to_merge:
   - babeld
+  - lldpd
   - luci-app-babeld
   - collectd-mod-dhcpleases
   - collectd-mod-olsrd

--- a/roles/cfg_openwrt/templates/corerouter/config/lldpd.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/lldpd.j2
@@ -1,0 +1,12 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+config lldpd config
+	option enable_cdp 0
+	option enable_fdp 0
+	option enable_sonmp 0
+	option enable_edp 0
+	option lldp_class 4
+	list interface 'loopback'
+{% for network in networks | selectattr('role', 'equalto', 'mesh') %}
+    {% set ifname = network['name'] if 'name' in network else network['role'] %}
+	list interface '{{ ifname }}'
+{% endfor %}


### PR DESCRIPTION
We need to get independent of the olsrd name protocol. Add lldpd as
standatarized protocol to get information about neighbors. To test it
just do

  lldpcli show neighbors

We can later use the information to feed owm with it.