### PR TITLE
Add the usage of a venv to the documentation

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,7 +1,8 @@
 ---
 exclude_paths:
-  - .github/
-  - .git
+  - ../.github
+  - ../.git
+  - ../venv
 
 warn_list:
   - literal-compare

--- a/.config/yaml-lint.yml
+++ b/.config/yaml-lint.yml
@@ -3,6 +3,9 @@
 
 extends: default
 
+ignore: |
+  venv
+
 rules:
   comments:
     level: error

--- a/FAQ.md
+++ b/FAQ.md
@@ -5,6 +5,8 @@
 Make sure to install ansible and clone the bbb-configs repository. Then install the requirements using:
 
 ```sh
+python3 -m venv venv
+source venv/bin/activate
 pip3 install -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ The provision of a router works by generating the necessary OpenWrt configs and 
 
 Using bbb-configs is quite simple. The TL;DR version for anyone not wanting to read the [FAQ](FAQ.md) is:
 
+    python3 -m venv venv
+    source venv/bin/activate
     pip3 install -r requirements.txt
     ./generate-images.sh    
 
 or
 
+    python3 -m venv venv
+    source venv/bin/activate
     pip3 install -r requirements.txt
     ansible-playbook play.yml --limit location-* --tags image
 


### PR DESCRIPTION
I added a quick info in regards to a virtualenv, since this should be the default when using python.

This way you don't collect dependencies from random projects in your homedir