### PR TITLE
treewide: use cdn.openwrt for downloads

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -1,7 +1,7 @@
 ---
 # default OpenWRT version to build from unless overridden
 openwrt_version: 21.02-SNAPSHOT
-imagebuilder: https://downloads.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}{{ target | replace('/','-') }}.Linux-x86_64.tar.xz
+imagebuilder: https://downloads.cdn.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}{{ target | replace('/','-') }}.Linux-x86_64.tar.xz
 feed: "src/gz openwrt_falter https://firmware.berlin.freifunk.net/feed/__FEED_VERSION__/packages/__INSTR_SET__/falter"
 
 

--- a/group_vars/model_ubnt_edgerouter_4.yml
+++ b/group_vars/model_ubnt_edgerouter_4.yml
@@ -6,4 +6,4 @@ target__packages__to_merge:
 
 # Somehow OpenWRT has messed up the name of resulting imagebuilder
 # for target octeon. Fixing it here
-imagebuilder: https://downloads.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}octeon.Linux-x86_64.tar.xz
+imagebuilder: https://downloads.cdn.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}octeon.Linux-x86_64.tar.xz

--- a/group_vars/model_ubnt_nanostation_loco_m5_xm.yml
+++ b/group_vars/model_ubnt_nanostation_loco_m5_xm.yml
@@ -1,5 +1,5 @@
 ---
-imagebuilder: "https://downloads.openwrt.org/releases/21.02-SNAPSHOT/targets/ath79/generic/openwrt-imagebuilder-21.02-SNAPSHOT-ath79-generic.Linux-x86_64.tar.xz"
+imagebuilder: "https://downloads.cdn.openwrt.org/releases/21.02-SNAPSHOT/targets/ath79/generic/openwrt-imagebuilder-21.02-SNAPSHOT-ath79-generic.Linux-x86_64.tar.xz"
 feed_version: "1.2.0-snapshot"
 override_target: "ubnt_nanostation-loco-m"
 target: ath79/generic


### PR DESCRIPTION
This will reduce the load on openwrt servers.