### PR TITLE
Imagebuild smallies

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -1,7 +1,8 @@
 ---
 # default OpenWRT version to build from unless overridden
 openwrt_version: 21.02-SNAPSHOT
-imagebuilder: https://downloads.cdn.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}{{ target | replace('/','-') }}.Linux-x86_64.tar.xz
+imagebuilder_filename: "openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}{{ target | replace('/','-') }}.Linux-x86_64.tar.xz"
+imagebuilder: "https://downloads.cdn.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/{{ imagebuilder_filename }}"
 feed: "src/gz openwrt_falter https://firmware.berlin.freifunk.net/feed/__FEED_VERSION__/packages/__INSTR_SET__/falter"
 
 

--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -12,7 +12,7 @@
 - name: Download Imagebuilder if upstream is newer
   get_url:
     url: "{{ imagebuilder }}"
-    dest: "{{ imagebuilder_dir }}"
+    dest: "{{ imagebuilder_dir }}/{{ imagebuilder_filename }}"
   when: '"http" in imagebuilder'
 
 - name: Copy Local Imagebuilder

--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -80,12 +80,9 @@
   command:
     chdir: "{{ imagebuild_dir }}"
     argv:
-      - "make"
-      - "image"
-      - "PROFILE={{ override_target | default(model) }}"
-      - "PACKAGES={{ packages | join(' ') }}"
-      - "DISABLED_SERVICES={{ disabled_services | join(' ') }}"
-      - "FILES={{ config_path }}"
+      - "bash"
+      - "-c"
+      - "make image PROFILE='{{ override_target | default(model) }}' PACKAGES='{{ packages | join(' ') }}' DISABLED_SERVICES='{{ disabled_services | join(' ') }}' FILES='{{ config_path }}' 1>&2"
   register: output
 
 - name: Clear imagedir
@@ -101,7 +98,7 @@
 
 - name: Write build log to output dir
   copy:
-    content: "{{ output.stdout }}"
+    content: "{{ output.stderr }}"
     dest: "{{ image_dir }}/{{ inventory_hostname }}.log"
 
 - name: Find output image

--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -108,6 +108,11 @@
     recurse: true
   register: image_list
 
+- name: Check Imagebuilder result
+  assert:
+    that: image_list.files | length > 0
+    fail_msg: 'No image was built, check log at {{ image_dir }}/{{ inventory_hostname }}.log'
+
 - name: Declare source
   set_fact:
     image_src: "{{ image_list.files | map(attribute='path') | list | first }}"

--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -1,4 +1,18 @@
 ---
+- name: Create images dir
+  file:
+    state: directory
+    path: "{{ image_dir }}"
+  run_once: true
+- name: Clear old image and logfile
+  file:
+    state: absent
+    path: "{{ item }}"
+  loop:
+    - "{{ image_dir }}/{{ inventory_hostname }}.bin"
+    - "{{ image_dir }}/{{ inventory_hostname }}.img"
+    - "{{ image_dir }}/{{ inventory_hostname }}.log"
+
 - name: Create Download directory
   file:
     path: "{{ imagebuilder_dir }}"
@@ -84,17 +98,6 @@
       - "-c"
       - "make image PROFILE='{{ override_target | default(model) }}' PACKAGES='{{ packages | join(' ') }}' DISABLED_SERVICES='{{ disabled_services | join(' ') }}' FILES='{{ config_path }}' 1>&2"
   register: output
-
-- name: Clear imagedir
-  file:
-    state: absent
-    path: "{{ image_dir }}"
-
-- name: (Re)-Create image dir
-  file:
-    state: directory
-    path: "{{ image_dir }}"
-  run_once: true
 
 - name: Write build log to output dir
   copy:


### PR DESCRIPTION
First two are about easier debugging (I'm sure @pmelange stumbled upon these the other day), third is about faster turnaround times, fourth fixes a race condition during images/ cleanup.


commit ddf33d0eb05974d13199a389e4182d999e964a7e
Author: Packet Please <pktpls@systemli.org>
Date:   Mon Aug 15 01:05:25 2022 +0200

    imagebuilder: work around Imagebuilders inconsistent exit codes
    
    Imagebuilder seems to correctly exit non-zero for some errors
    (e.g. opkg install) and simply skip over other errors (e.g. from
    squashfs image manipulation).
    
    The latter resulted in confusing "declare source" error messages
    which were hard to track down to their cause.
    
    We now check that there's an actual image built, and don't rely
    only on Imagebuilder's exit code for error reporting.

commit 80da4b59d1ac8454e2282c2a1a90e1d87d464ce5
Author: Packet Please <pktpls@systemli.org>
Date:   Mon Aug 15 01:02:34 2022 +0200

    imagebuilder: unify build output into stderr
    
    Some of the tools used by the Imagebuilder print to stderr,
    some print to stdout. This resulted in confusing and
    incomplete build logs, and made it hard to debug failed
    image builds.
    
    This commit introduces a dependency on Bash, which is
    used for stdio redirection.

commit 5a7f586a4ecf889d2f4282175453e38743d6b36e
Author: Packet Please <pktpls@systemli.org>
Date:   Mon Aug 15 01:00:11 2022 +0200

    imagebuilder: skip download whenever possible
    
    If get_url's dest param is a directory, it doesn't actually check
    whether the remote file is newer, and instead always downloads it
    regardless.

commit f68764d72ac23c796f8116a66be3e8d9bc682a83
Author: Packet Please <pktpls@systemli.org>
Date:   Fri Aug 19 23:28:39 2022 +0200

    imagebuilder: avoid race condition during cleanup
    
    The previous cleanup method removed more files than neccessary,
    and sometimes failed when simultaneous executions had already
    removed the files that it had just scanned.
    
    We also change this part of the cleanup to occur *before* the expensive
    download/unpack/run steps.
