### PR TITLE
Rixbox init

### DIFF
--- a/group_vars/location_rixbox/general.yml
+++ b/group_vars/location_rixbox/general.yml
@@ -1,0 +1,4 @@
+---
+# https://wiki.freifunk.net/Berlin:Standorte:Rixbox
+contact_nickname: 'Packet Please'
+contact_email: 'pktpls@systemli.org'

--- a/group_vars/location_rixbox/networks.yml
+++ b/group_vars/location_rixbox/networks.yml
@@ -1,0 +1,72 @@
+---
+
+# TODO: delete these old addresses:
+#       - mesh: 10.230.3.164/...
+
+ipv6_prefix: '2001:bf7:820:800::/56'
+
+# mgmt: 10.31.154.112/28
+# mesh: 10.31.160.240/28
+# dhcp: 10.230.39.0/24
+networks:
+
+  - vid: 10
+    role: mesh
+    name: mesh_rhnk
+    ipv6_subprefix: -10
+    prefix: 10.31.160.241/32
+
+  - vid: 20
+    role: mesh
+    name: mesh_ap1
+    ipv6_subprefix: -20
+    prefix: 10.31.160.242/32
+    mesh_ap: rixbox-ap1
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  - vid: 21
+    role: mesh
+    name: mesh_ap2
+    ipv6_subprefix: -21
+    prefix: 10.31.160.243/32
+    mesh_ap: rixbox-ap2
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  - vid: 22
+    role: mesh
+    name: mesh_ap3
+    ipv6_subprefix: -22
+    prefix: 10.31.160.244/32
+    mesh_ap: rixbox-ap3
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  - vid: 40
+    role: dhcp
+    ipv6_subprefix: 40
+    prefix: 10.230.39.0/24
+    assignments:
+      rixbox-core: 1
+    inbound_filtering: true
+    enforce_client_isolation: true
+
+  - vid: 42
+    role: mgmt
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 42
+    prefix: 10.31.154.112/28
+    assignments:
+      rixbox-core: 1
+      rixbox-ap1: 2
+      rixbox-ap2: 3
+      rixbox-ap3: 4
+      # AirOS LiteBeam RHNK
+      rixbox-rhnk: 5
+
+location__channel_assignments_11a_standard__to_merge:
+  rixbox-ap1: 36-20
+  rixbox-ap2: 40-20
+  rixbox-ap3: 44-20

--- a/group_vars/location_rixbox/owm.yml
+++ b/group_vars/location_rixbox/owm.yml
@@ -1,0 +1,5 @@
+---
+
+location_nice: Rixbox Espresso & Food
+latitude: 52.47890
+longitude: 13.43802

--- a/group_vars/location_rixbox/snmp.yml
+++ b/group_vars/location_rixbox/snmp.yml
@@ -1,0 +1,6 @@
+---
+
+snmp_devices:
+  - hostname: rixbox-rhnk
+    address: 10.31.154.117
+    snmp_profile: airos_8

--- a/group_vars/location_rixbox/ssh-keys.yml
+++ b/group_vars/location_rixbox/ssh-keys.yml
@@ -1,0 +1,6 @@
+---
+location__ssh_keys__to_merge:
+  - comment: martin@koltonowski.de
+    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHRiZkLdeg7pBS4m37vnDX1A9+iQ+Eim1A0XACSa5qfE martin@koltonowski.de
+  - comment: pktpls+bbb@systemli.org
+    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINVY2XHiLDXbj7TGWtUpKEb8+qKw/DrkiVbLiyvyRaCi pktpls+bbb@systemli.org

--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -21,6 +21,8 @@ model__packages__to_merge:
   - "-prometheus-node-exporter-lua-snmp6"
   - "-prometheus-node-exporter-lua-wifi"
   - "-prometheus-node-exporter-lua-wifi_stations"
+  # TODO reinstate this package once it's fixed in 1.3.0-snapshot feed
+  - "-luci-app-falter-owm-ant"
 
 compat_version: 1.1
 dsa_ports:

--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -1,0 +1,31 @@
+---
+
+# Factory flash instructions:
+# https://github.com/openwrt/openwrt/commit/a9839697896c4fdf8c44a06bbce466ce52493069
+
+openwrt_version: 22.03-SNAPSHOT
+feed_version: 1.3.0-snapshot
+target: ramips/mt7621
+
+# Our partition is only 7360k, not 8m.
+# We actually need to be below 7200k as the next squashfs padding step is 7400k.
+low_flash: true
+model__packages__to_merge:
+  - "-tcpdump-mini"
+  - "-curl"
+  - "-prometheus-node-exporter-lua"
+  - "-prometheus-node-exporter-lua-hostapd_stations"
+  - "-prometheus-node-exporter-lua-hostapd_ubus_stations"
+  - "-prometheus-node-exporter-lua-netstat"
+  - "-prometheus-node-exporter-lua-openwrt"
+  - "-prometheus-node-exporter-lua-snmp6"
+  - "-prometheus-node-exporter-lua-wifi"
+  - "-prometheus-node-exporter-lua-wifi_stations"
+
+compat_version: 1.1
+dsa_ports:
+  - lan1
+  - lan2
+  - lan3
+  - lan4
+  - lan5

--- a/host_vars/rixbox-ap1/base.yml
+++ b/host_vars/rixbox-ap1/base.yml
@@ -1,0 +1,8 @@
+---
+
+location: rixbox
+role: ap
+model: mikrotik_sxtsq-5-ac
+
+mac_override:
+  eth0: 2c:c8:1b:8a:96:ca

--- a/host_vars/rixbox-ap2/base.yml
+++ b/host_vars/rixbox-ap2/base.yml
@@ -1,0 +1,8 @@
+---
+
+location: rixbox
+role: ap
+model: mikrotik_sxtsq-5-ac
+
+mac_override:
+  eth0: 2c:c8:1b:8a:97:20

--- a/host_vars/rixbox-ap3/base.yml
+++ b/host_vars/rixbox-ap3/base.yml
@@ -1,0 +1,8 @@
+---
+
+location: rixbox
+role: ap
+model: mikrotik_sxtsq-5-ac
+
+mac_override:
+  eth0: 2c:c8:1b:8a:96:d8

--- a/host_vars/rixbox-core/base.yml
+++ b/host_vars/rixbox-core/base.yml
@@ -1,0 +1,23 @@
+---
+
+location: rixbox
+role: corerouter
+model: ubnt_usw-flex
+
+poemgr_power_budget: 24
+poemgr_ports:
+  # Port 2 is our uplink LiteBeam to RHNK, give it power budget priority
+  - name: lan2
+    port: 3
+    disabled: 0
+  # Simply disable the rest so Port 2 definitely gets all power
+  # TODO: enable these once blocktrron/poemgr#5 is merged
+  - name: lan3
+    port: 2
+    disabled: 1
+  - name: lan4
+    port: 1
+    disabled: 1
+  - name: lan5
+    port: 0
+    disabled: 1

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -52,3 +52,9 @@
     packages: "{{ packages + ['ip-bridge'] }}"
   when:
     - dsa_ports is defined
+
+- name: "Add poemgr if poemgr target"
+  set_fact:
+    packages: "{{ packages + ['poemgr'] }}"
+  when:
+    - poemgr_ports is defined

--- a/roles/cfg_openwrt/tasks/main.yml
+++ b/roles/cfg_openwrt/tasks/main.yml
@@ -46,6 +46,13 @@
       tags: always
   tags: always
 
+- name: Add poemgr config if poemgr target
+  template:
+    src: "{{ role_path }}/templates/common/config/poemgr.j2"
+    dest: "{{ config_path }}/etc/config/poemgr"
+  when:
+    - poemgr_ports is defined
+
 - name: Include fix_permissions.yml
   include_tasks:
     file: fix_permissions.yml

--- a/roles/cfg_openwrt/templates/common/config/poemgr.j2
+++ b/roles/cfg_openwrt/templates/common/config/poemgr.j2
@@ -1,0 +1,13 @@
+config poemgr 'settings'
+        option profile 'usw-flex'
+        option disabled '0'
+# TODO: uncomment this option once blocktrron/poemgr#5 is merged and shipped
+#        option power_budget '{{ poemgr_power_budget | default('0') }}'
+
+{% for poe in poemgr_ports | default([]) %}
+config port '{{ poe['name'] }}'
+        option name '{{ poe['name'] }}'
+        option port '{{ poe['port'] }}'
+        option disabled '{{ poe['disabled'] }}'
+
+{% endfor %}


### PR DESCRIPTION
Rixbox Espresso & Food @ Karl-Marx-Straße / Alfred-Scholz-Platz - very nice MABB site from 2014 that got new gear.

This soft-depends on blocktrron/poemgr#5 - it builds correctly without this patch, but fails to power up all devices. We can merge anyway - we give priority to the Rixbox-RHNK uplink and leave the APs disabled. Then after first boot, we install the patched poemgr package and enable the APs.

The wiki has been updated to reflect the new setup: https://wiki.freifunk.net/Berlin:Standorte:Rixbox