### PR TITLE
usw-flex: we require opkg and don't need low_flash

### DIFF
--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -9,9 +9,7 @@ target: ramips/mt7621
 
 # Our partition is only 7360k, not 8m.
 # We actually need to be below 7200k as the next squashfs padding step is 7400k.
-low_flash: true
 model__packages__to_merge:
-  - "-tcpdump-mini"
   - "-curl"
   - "-prometheus-node-exporter-lua"
   - "-prometheus-node-exporter-lua-hostapd_stations"


### PR DESCRIPTION
Somehow Github didn't pick up this last change I pushed last night...

We don't need `low_flash` since removing `curl` saves enough disk space. We also require `opkg` which would be removed by `low_flash`.