### PR TITLE
bht: correct Perrys Mail

### DIFF
--- a/group_vars/location_bht/general.yml
+++ b/group_vars/location_bht/general.yml
@@ -1,3 +1,3 @@
 ---
 contact_nickname: 'Perry'
-contact_email: 'sprotejesvalkata@gmail.com'
+contact_email: 'isprotejesvalkata [attt] gmail com'


### PR DESCRIPTION
This one was missed for quite a time. Please don't miss the
'i' at the beginning of the address! Using vim is no excuse
for that.

Signed-off-by: Martin Hübner <martin.hubner@web.de>