### PR TITLE
Fix contacts

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -53,9 +53,10 @@ This file might be fairly self-explanatory. Please mind that a contact is mandat
 ---
 contact_name: 'Petrosilius Quaccus'
 contact_nickname: 'Petro'
-contact_email: 'quaccus@example.com'
-# or:
-contact_email: 'https://config.berlin.freifunk.net/contact/446x/ImZmZnctZV0LTA0Ig.FFbQ8w._ZCA4hFY3zR8MdDVNrv3okqwPU'
+# contacts must be a list. Even if only one contact is given
+contacts:
+  - 'quaccus@example.com'
+  - 'https://config.berlin.freifunk.net/contact/446x/ImZmZnctZV0LTA0Ig.FFbQ8w._ZCA4hFY3zR8MdDVNrv3okqwPU'
 ```
 
 #### owm.yml

--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -2,10 +2,6 @@
 zonename: 'Europe/Berlin'
 timezone: 'CET-1CEST,M3.5.0,M10.5.0/3'
 
-contact_nickname: 'Freifunk Berlin Maintenance Team'
-contact_email: 'info@berlin.freifunk.net'
-
-
 dns_servers:
   - 46.182.19.48
   - 80.67.169.40

--- a/play.yml
+++ b/play.yml
@@ -2,5 +2,6 @@
 - hosts: all
   connection: local
   gather_facts: false
+  any_errors_fatal: true
   roles:
     - {role: cfg_openwrt}

--- a/roles/cfg_openwrt/templates/common/config/freifunk.j2
+++ b/roles/cfg_openwrt/templates/common/config/freifunk.j2
@@ -2,8 +2,18 @@ config public 'contact'
 {% if contact_name is defined %}
 	option name '{{ contact_name }}'
 {% endif %}
+{% if nickname is defined %}
 	option nickname '{{ contact_nickname }}'
-	option mail '{{ contact_email }}'
+{% endif %}
+{% if contact_email is defined %}
+	{{ (contact_email_depr) | mandatory('The option "contact_email" in location/general.yml is deprecated. Please rename that flag to "contacts" and make sure to transform it into to a list.') }}
+{% elif (community is true) and (contacts is undefined)%}
+	option mail 'info+{{ inventory_hostname }}@berlin.freifunk.net'
+{% else %}
+{% for contact in (contacts) | mandatory('Please add at least one contact information via the contacts-flag in location/general.yml. Fellow Freifunkas need to be able to contact you in case they want to mesh with you!') %}
+	list contact '{{ contact }}'
+{% endfor %}
+{% endif %}
 	option location '{{ location_nice }}'
 
 config public 'community'


### PR DESCRIPTION
## treewide: implement new contacts and community-flag

### contacts flag:
Setting the contacts flag will integrate any type of contact option in the
generated config. It must be a list and enables us to give several options
beside email addresses. One may also give a link to a matrix room, icq number
or whatever.

Example:
```yml
---
contact_name: 'Mr. Good-Code'
contact_nickname: 'gc-guy'
contacts:
  - 'some_address@example.org'
  - '01234 567890'
  - 'info@berlin.berlin'
  - 'https://matrix-raum.to'
...
```

### community-flag:
By setting 'community: true' in the locations general.yml, we can mark a site
as maintained by the bbb-configs administrator-team. This will fill the mail-field
in the configuration automatically with an email-address in the format
info+SITE_NAME@berlin.freifunk.net. This may be overridden by defining the
contacts flag

## Note:

This PR depends on https://github.com/freifunk-berlin/falter-packages/pull/330