### PR TITLE
Update requirements.txt to match latest available versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible >= 2.11
+ansible >= 2.13
 ansible_merge_vars >= 5.0.0
-jmespath >= 0.10.0
+jmespath >= 1.0.1
 netaddr >= 0.8.0
 ansible-lint >= 6.5.2
-yamllint >= 1.26.3
+yamllint >= 1.27.1


### PR DESCRIPTION
This pull request updates the requirements to the latest available versions to address errors that most likely occured due to outdated versions (#316).

ansible core has a newer version 2.13, older version are end of life
jmespath has now a stable 1.0.1 release
yamllint has an updated version 1.27.1