### PR TITLE
add support for wlan band replacing hwmode

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -28,14 +28,16 @@ int_port: eth0              # hardware-device on which swconfig works on
 
 wireless_devices:                       # definitions for the devices radios
   - name: 11a_standard                  # 5GHz radio
-    hwmode: 11a
+    band: 5g
     path: ffe09000.pcie/pci9000:00/9000:00:00.0/9000:01:00.0
     ifname_hint: wlan5
   - name: 11g_standard                  # 2.4GHz radio
-    hwmode: 11g
+    band: 2g
     path: ffe0a000.pcie/pcia000:02/a000:02:00.0/a000:03:00.0
     ifname_hint: wlan2
 ```
+
+Possible values for band are 2g for 2.4 GHz, 5g for 5 GHz, 6g for 6 GHz and 60g for 60 GHz. Band replaces hwmode since 21.02.2.
 
 For a model using DSA instead of swconfig, you may refer to [`model_ubnt_edgerouter_x_sfp.yml`](https://github.com/Freifunk-Spalter/bbb-configs/blob/master/group_vars/model_ubnt_edgerouter_x_sfp.yml)
 

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -26,7 +26,11 @@
 # Radio: {{ wd['name'] }}
 config wifi-device '{{ wd_id }}'
 	option type 'mac80211'
-	option hwmode '{{ wd['hwmode'] }}'
+  {% if 'band' in wd %}
+	option band '{{ wd['band'] }}'
+  {% elif 'hwmode' in wd %}
+        option hwmode '{{ wd['hwmode'] }}'
+  {% endif %}
 	option path '{{ wd['path'] }}'
 	option htmode 'VHT{{ bandwidth }}'
 	option channel '{{ channel }}'


### PR DESCRIPTION
As described in the OpenWRT documentation (https://openwrt.org/docs/guide-user/network/wifi/basic) hwmode was replaced by band in 21.02.2. This PR introduces support for using band instead of hwmode and updates the documentation accordingly. For easy transitioning if present band will be used instead of hwmode, but hwmode will still work.