### PR TITLE
Add htmode prefix

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -29,15 +29,19 @@ int_port: eth0              # hardware-device on which swconfig works on
 wireless_devices:                       # definitions for the devices radios
   - name: 11a_standard                  # 5GHz radio
     band: 5g
+    htmode_prefix: VHT
     path: ffe09000.pcie/pci9000:00/9000:00:00.0/9000:01:00.0
     ifname_hint: wlan5
   - name: 11g_standard                  # 2.4GHz radio
     band: 2g
+    htmode_prefix: VHT
     path: ffe0a000.pcie/pcia000:02/a000:02:00.0/a000:03:00.0
     ifname_hint: wlan2
 ```
 
 Possible values for band are 2g for 2.4 GHz, 5g for 5 GHz, 6g for 6 GHz and 60g for 60 GHz. Band replaces hwmode since 21.02.2.
+
+Possible values for htmode_prefix are HT (802.11n), VHT (802.11ac) and HE (802.11ax). The htmode_prefix setting corresponds with the htmode option.
 
 For a model using DSA instead of swconfig, you may refer to [`model_ubnt_edgerouter_x_sfp.yml`](https://github.com/Freifunk-Spalter/bbb-configs/blob/master/group_vars/model_ubnt_edgerouter_x_sfp.yml)
 

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -32,7 +32,11 @@ config wifi-device '{{ wd_id }}'
         option hwmode '{{ wd['hwmode'] }}'
   {% endif %}
 	option path '{{ wd['path'] }}'
-	option htmode 'VHT{{ bandwidth }}'
+  {% if 'htmode_prefix' in wd %}
+	option htmode '{{ wd['htmode_prefix'] }}{{ bandwidth }}'
+  {% else %}
+        option htmode 'VHT{{ bandwidth }}'
+  {% endif %}
 	option channel '{{ channel }}'
   {% if txpower %}
 	option txpower '{{ txpower }}'


### PR DESCRIPTION
This pull request adds support to specify an htmode_prefix that allows to specify the highes possible htmode for the wlan device. If accepted this should close #261.

What's missing is adding the setting for all models.