### PR TITLE
Git & ansible-lint changes

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -14,3 +14,4 @@ skip_list:
   - fqcn-builtins
   - experimental
   - yaml
+  - template-instead-of-copy

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */__pycache__/
 .vscode/
+venv/


### PR DESCRIPTION
This pull requests fixes ansible-lint by skipping the template-insted-of-copy-rule and adds the venv directory to .gitignore.