### PR TITLE
tunnelmanager: change default metric for client uplinks

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/tunnelmanager.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunnelmanager.j2
@@ -11,7 +11,7 @@ config tunnelmanager '{{ name }}'
 	option tunnel_timeout '{{ network['tunnel_timeout']|default(160) }}'
 	option check_interval '{{ network['tunnel_check_interval']|default(30) }}'
 	option up_script '{{ network['tunnel_up_script']|default('/usr/share/tunnelman/up.sh') }}'
-	option up_script_args '{{ network['tunnel_up_script_args']|default(network['tunnel_mesh_prefix_ipv4']) }}'
+	option up_script_args '{{ network['tunnel_up_script_args']|default(network['tunnel_mesh_prefix_ipv4']) }} 12800 0.4'
 	option down_script '{{ network['tunnel_down_script']|default('/usr/share/tunnelman/down.sh') }}'
   {% for gateway in groups['role_uplink_gateway'] %}
         # {{ gateway }}


### PR DESCRIPTION
This should fix #308 and once merged #334 will add this to the documentation.