### PR TITLE
Make APs use NTP server of the core router

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -103,6 +103,7 @@ networks:
     prefix: 10.31.83.112/28
     gateway: 1
     dns: 1
+    ntp: 1                    # used to tell accesspoints to use the ntp server of the core router
     ipv6_subprefix: 1
     assignments:              # assign static(!) addresses from mngt-network to individual devices/interfaces.
       magda-core: 1           # core router gets 1st address. In result it will be reachable at 10.31.83.113

--- a/roles/cfg_openwrt/templates/common/config/system.j2
+++ b/roles/cfg_openwrt/templates/common/config/system.j2
@@ -18,9 +18,16 @@ config system
 config timeserver 'ntp'
         option enabled '1'
         option enable_server '{{ (role == 'corerouter' or role  == 'uplink_gateway') | int }}'
+{% if networks is defined %}
+{% set mgmtnetwork = networks | selectattr('role', 'equalto', 'mgmt') | default([], true) | list | first %}
+{% endif %}
+{% if role == 'ap' and mgmtnetwork is defined and 'ntp' in mgmtnetwork %}
+        list server '{{ mgmtnetwork['prefix'] | ansible.utils.ipaddr(mgmtnetwork['ntp']) | ansible.utils.ipaddr('address') }}'
+{% else %}
 {% for ntp_server in ntp_servers %}
         list server '{{ ntp_server }}'
 {% endfor %}
+{% endif %}
 
 {% for led in leds | default([]) %}
 


### PR DESCRIPTION
This pull request should address the remaining stuff to close #4.

To actually start using the NTP server on the core router the corresponding networks files have to be changed later on.