### PR TITLE
l105-gw: Add community-flag

### DIFF
--- a/group_vars/location_l105/general.yml
+++ b/group_vars/location_l105/general.yml
@@ -1,0 +1,2 @@
+---
+community: true


### PR DESCRIPTION
merging PR #320 broke accidentially the CI. Fixing that, by flagging l105-gw as community-site.

Signed-off-by: Martin Hübner <martin.hubner@web.de>