### PR TITLE
huette15, kts13: decrease number of tunnels, set new ip addrs

### DIFF
--- a/group_vars/location_huette15/networks.yml
+++ b/group_vars/location_huette15/networks.yml
@@ -56,9 +56,9 @@ networks:
     role: ext
     name: easybell
     untagged: true
-    tunnel_wan_ip: 192.168.178.2/24
+    tunnel_wan_ip: 192.168.178.178/24
     tunnel_wan_gw: 192.168.178.1
-    tunnel_connections: 2
+    tunnel_connections: 1
     tunnel_timeout: 600
     tunnel_mesh_prefix_ipv4: 10.31.82.192/28
 

--- a/group_vars/location_huette15/networks.yml
+++ b/group_vars/location_huette15/networks.yml
@@ -10,23 +10,25 @@
 # 10.31.77.55
 # 10.31.77.56
 
-ipv6_prefix: 2001:bf7:820:700::/56
+# 10.31.184.0/26
+# 10.31.184.0/29 - mgmt
+# 10.31.184.8/29 - mesh
+# 10.31.184.16/28 - prdhcp todo
+# 10.31.184.32/27 - dhcp
+ipv6_prefix: 2001:bf7:820:2400::/56
 
-# mesh: 10.31.82.192/28
-# mgmt: 10.31.107.224/28
-# dhcp: 10.31.166.128/26
 networks:
 
   - vid: 20
     role: mesh
     name: mesh_core
-    prefix: 10.31.82.193/32
+    prefix: 10.31.184.8/32
     ipv6_subprefix: -1
 
   - vid: 21
     role: mesh
     name: mesh_huette
-    prefix: 10.31.82.194/32
+    prefix: 10.31.184.9/32
     ipv6_subprefix: -2
     mesh_metric: 1024
     mesh_ap: huette15-ap1
@@ -37,14 +39,14 @@ networks:
     role: dhcp
     inbound_filtering: true
     enforce_client_isolation: true
-    prefix: 10.31.166.128/26
+    prefix: 10.31.184.32/27
     ipv6_subprefix: 0
     assignments:
       huette15-core: 1
 
   - vid: 42
     role: mgmt
-    prefix: 10.31.107.224/28
+    prefix: 10.31.184.0/29
     gateway: 1
     dns: 1
     ipv6_subprefix: 1
@@ -60,10 +62,12 @@ networks:
     tunnel_wan_gw: 192.168.178.1
     tunnel_connections: 1
     tunnel_timeout: 600
-    tunnel_mesh_prefix_ipv4: 10.31.82.192/28
+    tunnel_mesh_prefix_ipv4: 10.31.184.10/32
 
 location__channel_assignments_11a_standard__to_merge:
-  huette15-ap1: 44-40-8                               # 8 dBm + 15 dBi gain = 23 dBm (with UMA-D antenna)
+  # 8 dBm + 15 dBi gain = 23 dBm (with UMA-D antenna)
+  huette15-ap1: 44-40-8
 
 location__channel_assignments_11g_standard__to_merge:
-  huette15-ap1: 13-20-13                              # 13 dBm + 10 dBi gain = 23 dBm (with UMA-D antenna)
+  # 13 dBm + 10 dBi gain = 23 dBm (with UMA-D antenna)
+  huette15-ap1: 13-20-13

--- a/group_vars/location_kts13/networks.yml
+++ b/group_vars/location_kts13/networks.yml
@@ -47,7 +47,7 @@ networks:
     untagged: true
     tunnel_wan_ip: '192.168.254.2/24'
     tunnel_wan_gw: '192.168.254.1'
-    tunnel_connections: 2
+    tunnel_connections: 1
     tunnel_timeout: 600
     tunnel_mesh_prefix_ipv4: '10.31.166.192/28'
 


### PR DESCRIPTION
huette15 is getting new IP addresses because of a collision with Museumsinsel.

huette15 and kts13 are getting `tunnel_connections = 1` so we don't create multiple Wireguard tunnels there, might avoid funky routing business.