### PR TITLE
model: wdr4900: bump wdr4900 to 22.03

### DIFF
--- a/group_vars/model_tplink_tl_wdr4900_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4900_v1.yml
@@ -1,9 +1,6 @@
 ---
 target: mpc85xx/p1010
 
-# quirk because of https://github.com/openwrt/openwrt/issues/9027
-openwrt_version: 21.02-SNAPSHOT
-
 switch_ports: 6
 switch_int_port: 0
 switch_ignore_ports: []


### PR DESCRIPTION
WDR4900 boots now with extra spi-loader.