### PR TITLE
Add DAWN to support band-steering for large nodes

### DIFF
--- a/host_vars/gub37-core/base.yml
+++ b/host_vars/gub37-core/base.yml
@@ -5,3 +5,4 @@ role: corerouter
 model: "avm_fritzbox-7530"
 
 wireless_profile: freifunk_default
+wifi_roaming: true

--- a/host_vars/gub37-hof-s/base.yml
+++ b/host_vars/gub37-hof-s/base.yml
@@ -3,3 +3,5 @@
 location: gub37
 role: ap
 model: "mikrotik_sxtsq-5-ac"
+
+wifi_roaming: true

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -12,6 +12,19 @@
     - airos_dfs_reset|default([])|length > 0
     - role == 'corerouter'
 
+- name: "Add Dawn + Luci app for corerouters"
+  set_fact:
+    packages: "{{ packages + [item] }}"
+  when:
+    - role == 'corerouter' or role == 'ap'
+    - not (low_mem | default(false))
+    - not (low_flash | default(false))
+    - wifi_roaming | default(false)
+  loop:
+    - dawn
+    - luci-app-dawn
+    - umdns
+
 - name: "Add tunnelmanager if configured"
   set_fact:
     packages: "{{ packages + ['falter-berlin-tunnelmanager'] }}"

--- a/roles/cfg_openwrt/templates/ap/config/dawn.j2
+++ b/roles/cfg_openwrt/templates/ap/config/dawn.j2
@@ -1,0 +1,83 @@
+{% set network_mgmt = networks | selectattr('role', 'equalto', 'mgmt') | first %}
+{% set mgmt_broadcast = network_mgmt['prefix'] | ansible.utils.ipaddr('broadcast') %}
+{% if wifi_roaming | default(false) %}
+config local
+	option loglevel '0'
+
+config network
+	option broadcast_ip '{{ mgmt_broadcast }}'
+	option broadcast_port '1025'
+	option tcp_port '1026'
+	option network_option '2'
+	option shared_key 'dawn@{{ location_nice|default(location) }}'
+	option iv 'thisisaniv!'
+	option use_symm_enc '0'
+	option collision_domain '-1'
+	option bandwidth '-1'
+
+config hostapd
+	option hostapd_dir '/var/run/hostapd'
+
+config times
+	option con_timeout '60'
+	option update_client '10'
+	option remove_client '15'
+	option remove_probe '30'
+	option remove_ap '460'
+	option update_hostapd '10'
+	option update_tcp_con '10'
+	option update_chan_util '5'
+	option update_beacon_reports '20'
+
+config metric 'global'
+	option min_probe_count '3'
+	option bandwidth_threshold '6'
+	option use_station_count '0'
+	option max_station_diff '1'
+	option eval_probe_req '0'
+	option eval_auth_req '0'
+	option eval_assoc_req '0'
+	option kicking '3'
+	option kicking_threshold '10'
+	option deny_auth_reason '1'
+	option deny_assoc_reason '17'
+	option min_number_to_kick '3'
+	option chan_util_avg_period '3'
+	option set_hostapd_nr '0'
+	option duration '5' # This is required, otherwise it's not kicking
+	option rrm_mode 'pat'
+
+config metric '802_11g'
+	option initial_score '80'
+	option ht_support '5'
+	option vht_support '5'
+	option no_ht_support '0'
+	option no_vht_support '0'
+	option rssi '15'
+	option rssi_val '-60'
+	option low_rssi_val '-80'
+	option low_rssi '-15'
+	option chan_util '0'
+	option chan_util_val '140'
+	option max_chan_util '-15'
+	option max_chan_util_val '170'
+	option rssi_weight '0'
+	option rssi_center '-70'
+
+config metric '802_11a'
+	option initial_score '100'
+	option ht_support '5'
+	option vht_support '5'
+	option no_ht_support '0'
+	option no_vht_support '0'
+	option rssi '15'
+	option rssi_val '-60'
+	option low_rssi_val '-80'
+	option low_rssi '-15'
+	option chan_util '0'
+	option chan_util_val '140'
+	option max_chan_util '-15'
+	option max_chan_util_val '170'
+	option rssi_weight '0'
+	option rssi_center '-70'
+{% endif %}

--- a/roles/cfg_openwrt/templates/ap/config/umdns.j2
+++ b/roles/cfg_openwrt/templates/ap/config/umdns.j2
@@ -1,0 +1,3 @@
+config umdns
+	option jail 1
+	list network mgmt

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -53,6 +53,13 @@ config wifi-device '{{ wd_id }}'
   {% if 'disabled' in wd_config %}
 	option disabled '{{ wd_config['disabled']|int }}'
   {% endif %}
+	option bss_transition '1'
+	option wnm_sleep_mode '1'
+	option time_advertisement '2'
+	option time_zone 'GMT0'
+	option ieee80211k '1'
+	option rrm_neighbor_report '1'
+	option rrm_beacon_report '1'
 
   {% for iface in wd_ifaces %}
     {% set mesh_net = false %}

--- a/roles/cfg_openwrt/templates/corerouter/config/dawn.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dawn.j2
@@ -1,0 +1,83 @@
+{% set network_mgmt = networks | selectattr('role', 'equalto', 'mgmt') | first %}
+{% set mgmt_broadcast = network_mgmt['prefix'] | ansible.utils.ipaddr('broadcast') %}
+{% if wifi_roaming | default(false) %}
+config local
+	option loglevel '0'
+
+config network
+	option broadcast_ip '{{ mgmt_broadcast }}'
+	option broadcast_port '1025'
+	option tcp_port '1026'
+	option network_option '2'
+	option shared_key 'dawn@{{ location_nice|default(location) }}'
+	option iv 'thisisaniv!'
+	option use_symm_enc '0'
+	option collision_domain '-1'
+	option bandwidth '-1'
+
+config hostapd
+	option hostapd_dir '/var/run/hostapd'
+
+config times
+	option con_timeout '60'
+	option update_client '10'
+	option remove_client '15'
+	option remove_probe '30'
+	option remove_ap '460'
+	option update_hostapd '10'
+	option update_tcp_con '10'
+	option update_chan_util '5'
+	option update_beacon_reports '20'
+
+config metric 'global'
+	option min_probe_count '3'
+	option bandwidth_threshold '6'
+	option use_station_count '0'
+	option max_station_diff '1'
+	option eval_probe_req '0'
+	option eval_auth_req '0'
+	option eval_assoc_req '0'
+	option kicking '3'
+	option kicking_threshold '10'
+	option deny_auth_reason '1'
+	option deny_assoc_reason '17'
+	option min_number_to_kick '3'
+	option chan_util_avg_period '3'
+	option set_hostapd_nr '0'
+	option duration '5' # This is required, otherwise it's not kicking
+	option rrm_mode 'pat'
+
+config metric '802_11g'
+	option initial_score '80'
+	option ht_support '5'
+	option vht_support '5'
+	option no_ht_support '0'
+	option no_vht_support '0'
+	option rssi '15'
+	option rssi_val '-60'
+	option low_rssi_val '-80'
+	option low_rssi '-15'
+	option chan_util '0'
+	option chan_util_val '140'
+	option max_chan_util '-15'
+	option max_chan_util_val '170'
+	option rssi_weight '0'
+	option rssi_center '-70'
+
+config metric '802_11a'
+	option initial_score '100'
+	option ht_support '5'
+	option vht_support '5'
+	option no_ht_support '0'
+	option no_vht_support '0'
+	option rssi '15'
+	option rssi_val '-60'
+	option low_rssi_val '-80'
+	option low_rssi '-15'
+	option chan_util '0'
+	option chan_util_val '140'
+	option max_chan_util '-15'
+	option max_chan_util_val '170'
+	option rssi_weight '0'
+	option rssi_center '-70'
+{% endif %}

--- a/roles/cfg_openwrt/templates/corerouter/config/umdns.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/umdns.j2
@@ -1,0 +1,3 @@
+config umdns
+	option jail 1
+	list network mgmt


### PR DESCRIPTION
Larger nodes often have multiple radios serving the same SSIDs. In order to improve end-user experiences, enable band-steering using Dawn for `corerouter` and `ap` roles.

This branch has been deployed successfully at the gub37 & gruni73 nodes.