### PR TITLE
[WIP] eap225: enable watchdog for wifi bug

### DIFF
--- a/group_vars/model_tplink_eap225_outdoor_v1.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v1.yml
@@ -4,6 +4,7 @@ target: ath79/generic
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca9888-ct"
   - "kmod-ath10k-smallbuffers ath10k-firmware-qca9888"
+  - "athwatch"
 
 int_port: eth0
 


### PR DESCRIPTION
Workaround for #117. Need to wait for the package to be built. It's a crappy but simple watchdog that tails `logcat` and reboots if there's certain output about a certain ath10k wifi bug.