### PR TITLE
prometheus: avoid ip --json

### DIFF
--- a/roles/cfg_openwrt/files/common/prom-catalog-register.sh
+++ b/roles/cfg_openwrt/files/common/prom-catalog-register.sh
@@ -24,7 +24,7 @@ log "started. Registering with following labels: hostname: $hostname, role: $rol
 log "Retrieving IPv6 Address"
 
 mgmtdev=$(ubus call network.interface.mgmt status | jsonfilter -e '@.l3_device')
-mgmtip="$(ip -j -6 addr show "$mgmtdev" scope global | jsonfilter -e '@[*].addr_info[*].local' | head -n1)"
+mgmtip="$(ip -6 addr show "$mgmtdev" scope global | awk '{ match($0, /[0-9a-f:]+\/\d+\s/); ip = substr($0, RSTART, RLENGTH); print ip }' | grep . | head -n1)"
 
 if [[ "$mgmtip" != "2001:bf7:*" ]]; then
   log "Public IPv6 is not part of freifunk berlin prefix"


### PR DESCRIPTION
Due to space constraints, we don't install `ip-tiny` nor `ip-full` which provide JSON output. Instead we only have Busybox's `ip`, so we have to parse its output on our own.