### PR TITLE
rhnk: updates from Saturday

### DIFF
--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -103,7 +103,7 @@ networks:
     assignments:
       rhnk-core: 1
 
-  - vid: 42
+  - vid: 420
     role: mgmt
     prefix: 10.31.153.0/27
     gateway: 1

--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -26,6 +26,20 @@ networks:
     mesh_metric: 128
     ptp: true
 
+  - vid: 12
+    role: mesh
+    name: mesh_philmel60
+    prefix: 10.230.3.12/32
+    ipv6_subprefix: -12
+    ptp: true
+
+  - vid: 13
+    role: mesh
+    name: mesh_richardplatz
+    prefix: 10.230.3.13/32
+    ipv6_subprefix: -13
+    ptp: true
+
   - vid: 15
     role: mesh
     name: mesh_emma
@@ -105,6 +119,12 @@ networks:
       # AirFiber 60-LR, firmware v2.6.0
       rhnk-rhxb: 11
 
+      # Mikrotik Cube 60 Pro (dead)
+      rhnk-philmel-60ghz: 12
+
+      # Mikrotik Cube 60 Pro (dead)
+      rhnk-richardplatz: 13
+
       # Powerbeam 5AC 400 ISO, AirOS 8.7.11
       rhnk-emma: 15
 
@@ -113,9 +133,6 @@ networks:
 
       # Rocket 5AC Lite, AirOS 8.7.0
       rhnk-wsw-5ghz: 21
-
-      # Nanostation Loco M5, AirOS 6.3.6
-      rhnk-ono-5ghz: 22
 
       # Rocket 5AC Lite, AirOS 8.7.11
       rhnk-ssw-5ghz: 23
@@ -126,7 +143,7 @@ networks:
       # Rocket 5AC Lite
       rhnk-nno-5ghz: 25
 
-      rhnk-ap3: 27
-      rhnk-ap2: 28
-      rhnk-ap1: 29
+      rhnk-nf-nw-5ghz: 27
+      rhnk-nf-no-5ghz: 28
+      rhnk-nf-so-5ghz: 29
       rhnk-nf-bvv: 30

--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -71,6 +71,15 @@ networks:
     prefix: 10.230.3.25/32
     ipv6_subprefix: -25
 
+  - vid: 30
+    role: mesh
+    name: mesh_nf_bvv
+    prefix: 10.230.3.30/32
+    ipv6_subprefix: -30
+    mesh_ap: rhnk-nf-bvv
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
   - vid: 40
     role: dhcp
     prefix: 10.230.3.64/26
@@ -120,4 +129,4 @@ networks:
       rhnk-ap3: 27
       rhnk-ap2: 28
       rhnk-ap1: 29
-      rhnk-platz: 30
+      rhnk-nf-bvv: 30

--- a/host_vars/rhnk-nf-bvv/base.yml
+++ b/host_vars/rhnk-nf-bvv/base.yml
@@ -1,0 +1,7 @@
+---
+
+location: rhnk
+role: ap
+model: "tplink_eap225-outdoor-v1"
+
+wireless_profile: freifunk_default

--- a/host_vars/rhnk-platz/base.yml
+++ b/host_vars/rhnk-platz/base.yml
@@ -1,5 +1,0 @@
----
-
-location: rhnk
-role: ap
-model: "ubnt_nanostation-m2_xm"


### PR DESCRIPTION
The most significant change is the `mgmt` network now being on VLAN 420. See #299.