### PR TITLE
get rid of compat_version checking

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -38,5 +38,3 @@ all_sysctl__to_merge:
 
   # especially on low mem devices this is important
   vm.min_free_kbytes: 1024
-
-compat_version: 1.0

--- a/group_vars/model_netgear_wax202.yml
+++ b/group_vars/model_netgear_wax202.yml
@@ -1,8 +1,6 @@
 ---
 target: ramips/mt7621
 
-compat_version: 1.1
-
 dsa_ports:
   - wan
   - lan1

--- a/group_vars/model_ubnt_edgerouter_x.yml
+++ b/group_vars/model_ubnt_edgerouter_x.yml
@@ -1,8 +1,6 @@
 ---
 target: ramips/mt7621
 
-compat_version: 1.1
-
 dsa_ports:
   - eth0
   - eth1

--- a/group_vars/model_ubnt_edgerouter_x_sfp.yml
+++ b/group_vars/model_ubnt_edgerouter_x_sfp.yml
@@ -1,8 +1,6 @@
 ---
 target: ramips/mt7621
 
-compat_version: 1.1
-
 dsa_ports:
   - eth0
   - eth1

--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -20,7 +20,6 @@ model__packages__to_merge:
   # TODO reinstate this package once it's fixed in 1.3.0-snapshot feed
   - "-luci-app-falter-owm-ant"
 
-compat_version: 1.1
 dsa_ports:
   - lan1
   - lan2

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -1,8 +1,6 @@
 ---
 target: ramips/mt7621
 
-compat_version: 1.1
-
 dsa_ports:
   - lan
 

--- a/host_vars/scharni-ap-keller/base.yml
+++ b/host_vars/scharni-ap-keller/base.yml
@@ -3,5 +3,3 @@
 location: scharni
 role: ap
 model: "tplink_eap225-outdoor-v1"
-
-wireless_profile: freifunk_default_owe_transition

--- a/host_vars/scharni-ap-kneipe/base.yml
+++ b/host_vars/scharni-ap-kneipe/base.yml
@@ -3,5 +3,3 @@
 location: scharni
 role: ap
 model: "zyxel_nwa50ax"
-
-wireless_profile: freifunk_default_owe_transition

--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -89,6 +89,12 @@
     state: "absent"
   when: 'imagebuilder_disable_signature_check is defined and imagebuilder_disable_signature_check'
 
+- name: Override compat_version check to bbb-configs exclusive value 9.9
+  lineinfile:
+    path: "{{ imagebuild_dir }}/include/image-commands.mk"
+    search_string: "compat_version=$(if $(DEVICE_COMPAT_VERSION),$(DEVICE_COMPAT_VERSION),1.0)"
+    line: "compat_version=9.9"
+
 - name: Run Imagebuilder
   changed_when: false
   command:

--- a/roles/cfg_openwrt/templates/common/config/system.j2
+++ b/roles/cfg_openwrt/templates/common/config/system.j2
@@ -5,14 +5,12 @@ config system
         option ttylogin '0'
         option log_size '64'
         option urandom_seed '0'
+        option compat_version '9.9' # hardcoded to a bbb-configs exclusive version identifier, matches patch in image builder, because we dont retain device config.
 {% if role == 'corerouter' or role  == 'uplink_gateway' %}
 	option latitude '{{ latitude|default(0) }}'
 	option longitude '{{ longitude|default(0) }}'
 	option altitude '60.000000000000000'
 	option location '{{ location_nice|default(location) }}'
-{% endif %}
-{% if dsa_ports is defined %}
-	option compat_version '{{ compat_version }}'
 {% endif %}
 
 config timeserver 'ntp'


### PR DESCRIPTION
this involves hardcoding the resulting compat_version in the image metadata to 1.0 and also hardcoding it within the config. We dont need the compat_version check because we ship the config within the image.

If the device you are flashing is running at a higher compat_version you likely have to use sysupgrade -n in order to fix it again