### PR TITLE
locations: add remaining missing contacts

### DIFF
--- a/group_vars/location_agym/general.yml
+++ b/group_vars/location_agym/general.yml
@@ -1,0 +1,2 @@
+---
+community: true

--- a/group_vars/location_dragonkiez_buero/general.yml
+++ b/group_vars/location_dragonkiez_buero/general.yml
@@ -1,0 +1,4 @@
+---
+contact_nickname: 'Perry'
+contacts:
+  - 'isprotejesvalkata [attt] gmail com'

--- a/group_vars/location_grueni/general.yml
+++ b/group_vars/location_grueni/general.yml
@@ -1,0 +1,3 @@
+---
+contacts:
+  - 'me [ät] robertfoss [dot] se'

--- a/group_vars/location_habersaath/general.yml
+++ b/group_vars/location_habersaath/general.yml
@@ -1,0 +1,3 @@
+---
+contacts:
+  - 'noc@stadtfunk.net'

--- a/group_vars/location_manstein10/general.yml
+++ b/group_vars/location_manstein10/general.yml
@@ -1,0 +1,3 @@
+---
+contacts:
+  - '365ff@systemli.org'

--- a/group_vars/location_newyorck/general.yml
+++ b/group_vars/location_newyorck/general.yml
@@ -1,0 +1,4 @@
+---
+contacts:
+  - 'NewYorck Freifunk AG'
+  - 'newyorck [ät] so36 [dot] net'

--- a/host_vars/ak36-gw/general.yml
+++ b/host_vars/ak36-gw/general.yml
@@ -1,0 +1,2 @@
+---
+community: true

--- a/host_vars/ohlauer-gw/general.yml
+++ b/host_vars/ohlauer-gw/general.yml
@@ -1,0 +1,2 @@
+---
+community: true

--- a/host_vars/saarbruecker-gw/general.yml
+++ b/host_vars/saarbruecker-gw/general.yml
@@ -1,0 +1,2 @@
+---
+community: true


### PR DESCRIPTION
- agym: community, stammt aus der MABB-Förderung, damals wurde das als Projekt zusammen mit einer AG an der Schule aufgebaut
- ak36: community, Zugang über den Speedbone-Kontakt oder die Amateurfunker
- habersaath: stadtfunk
- ohlauer: community, Zugang über up42 GmbH bzw. Hausmeister
- saarbruecker: community, Zugang über Hausmeister

---

- dragonkiez_buero: cc @pmelange you seem to be working with them
- grueni: cc @robertfoss this location can probably be removed?
- manstein10: wird von @ideesnoires gepflegt
- newyorck: wird von @noxilixon gepflegt, willst du eine