### PR TITLE
[DRAFT] Update changes from bbb to wiki.freifunk.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 */__pycache__/
 .vscode/
 venv/
+.env

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 BBB-Configs manages and provisions OpenWrt mesh nodes in the city-wide backbone of Freifunk Berlin via ansible. It abstracts the typical OpenWrt mesh config to generic templates. Those templates provision all locations more or less the same helping the maintainers to orientate on all sites.
 
-The provision of a router works by generating the necessary OpenWrt configs and feeding the OpenWrt-Imagebuilder with it. In the end, ansible generates a self-contained binary image ready to be flashed on a router. Due to the self-contained property bbb-configs can ensure to function properly on a router in a specific location. Maintainers can remotely upgrade sites without having to worry about wrong configurations.
+The provision of a router works by generating the necessary OpenWrt configs and feeding the OpenWrt-Imagebuilder with it. In the end, ansible generates a self-contained binary image ready to be flashed on a router. Due to the self-contained property bbb-configs can ensure to function properly on a router in a specific location.
+Maintainers can remotely upgrade sites without having to worry about wrong configurations.
 
 ## Getting Started
 
@@ -24,17 +25,31 @@ or
 
 ## How it Works
 
-Ansible playbooks offer simple, repeatable, and reusable execution of tasks making them perfectly fit into the Freifunk world. Daily Freifunk maintenance consists of updating a location to the newest software version or deploying a new service. Sometimes new sites are acquired with the constraint of producing a network plan and flashing dozens of routers with OpenWrt. We map these tasks in files following the YAML format and integrate them into our playbook. Commonly, playbooks execute ansible tasks on remote machines changing configuration files or installing new software on runtime. Here, we use the playbook to perform tasks with the outcome of a binary image containing all configuration files on compile time. The only remote execution at runtime on the network device may be a sysupgrade-command of the final binary.
+Ansible playbooks offer simple, repeatable, and reusable execution of tasks making them perfectly fit into the Freifunk world. Daily Freifunk maintenance consists of updating a location to the newest software version or deploying a new service. Sometimes new sites are acquired with the constraint of producing a network plan and flashing dozens of routers with OpenWrt.
+We map these tasks in files following the YAML format and integrate them into our playbook. Commonly, playbooks execute ansible tasks on remote machines changing configuration files or installing new software on runtime. Here, we use the playbook to perform tasks with the outcome of a binary image containing all configuration files on compile time.
+The only remote execution at runtime on the network device may be a sysupgrade-command of the final binary.
 
-We follow the common ansible scheme of locations and hosts. We see a location as an autonomous layer 2 domain connected with other locations in a layer 3 fashion. We call these layer 2 constructions a core-router setup implying only one router is acting as a gateway and provides services, like DHCP. Further, these routers maintain layer 3 connectivity to other locations with mesh routing daemons like babeld. A core setup can have an unbound number of access points. As a layer 2 domain, a network client can roam between all devices, and no routing is done inside the location.  Mapping that on our playbook, the location contains the network plan and also service descriptions that are valid for all hosts inside a location. Host entities describe the physical or virtual network entity by its actual hardware, e.g. Belkin RT3200 router, and can also override service descriptions set by the location. The mapping between hosts and location is done inside the host's definition by the location variable.
+We follow the common ansible scheme of locations and hosts. We see a location as an autonomous layer 2 domain connected with other locations in a layer 3 fashion. We call these layer 2 constructions a core-router setup implying only one router is acting as a gateway and provides services, like DHCP.
+Further, these routers maintain layer 3 connectivity to other locations with mesh routing daemons like babeld. A core setup can have an unbound number of access points. As a layer 2 domain, a network client can roam between all devices, and no routing is done inside the location.  Mapping that on our playbook,
+the location contains the network plan and also service descriptions that are valid for all hosts inside a location. Host entities describe the physical or virtual network entity by its actual hardware, e.g. Belkin RT3200 router, and can also override service descriptions set by the location. The mapping between hosts and location is done inside the host's definition by the location variable.
 
-The image compilation takes the variables defined by the hosts and location files to generate the OpenWrt config syntax for each physical or virtual host. The generation is based on template files written in the Jinja language. Based on the actual hardware, different files are included to fit the underlying system and drivers, e.g. some drivers expect network config concerning the distributed switching architecture, and some use the legacy sw-config format. Based on the predefined roles, core-router, access point, and gateway, a customized set of tasks are executed. The last step is to download the correct OpenWrt-Imagebuilder for the host and give it all generated config files. The Imagebuilder generates a binary image embedded with the customized config for this one host in the particular location. Flashing this image to a router will set the router after boot directly in the correct operating state. Further, this router will not be able to lose any of its configurations since it is embedded into its image.
+The image compilation takes the variables defined by the hosts and location files to generate the OpenWrt config syntax for each physical or virtual host. The generation is based on template files written in the Jinja language. Based on the actual hardware, different files are included to fit the underlying system and drivers,
+e.g. some drivers expect network config concerning the distributed switching architecture, and some use the legacy sw-config format. Based on the predefined roles, core-router, access point, and gateway, a customized set of tasks are executed. The last step is to download the correct OpenWrt-Imagebuilder for the host and give it all generated config files.
+The Imagebuilder generates a binary image embedded with the customized config for this one host in the particular location. Flashing this image to a router will set the router after boot directly in the correct operating state. Further, this router will not be able to lose any of its configurations since it is embedded into its image.
 
 If we need someone to reproduce our setup, the person can just generate the image for the involved routers, aka hosts, and provision them. Everyone can reproduce our setup and can work with us on our configurations from all other the world. In the future, it may be possible to abstract the actual router hardware with QEMU opening new interesting use cases.
 
 ## Developers and Maintainers
 
 If you want to use bbb-configs for locations that are not included in bbb-configs yet or to work on a fork of the code yourself then see the [Developers Guide](DEVELOPER.md).
+
+## Automaticly updating to wiki.freifunk.net
+
+If you updated certain locations you can automaticly updating their wikiarticle using the wikitag:
+    ansible-playbook play.yml --tags wiki
+This works by automaticly replacing semantic values in the coresponding article resulting in the placeholders throughout the article being replaced with the new values. For an example you can have a look at the [wikiarticle of Fesev](https://wiki.freifunk.net/Berlin:Standorte:Fesev).
+To add this option to your wikiarticle add a section called "Konfiguration" and replace all values that you want to automaticly change as you can see in the example-article. If you want to add a new location you can start with [this template](https://wiki.freifunk.net/Berlin:Standorte:Template).
+Please note that for the first time you have to copy the wikiupdateroutput from /tmp/ansible-openwrt/wikiupdater/ into your acrticle or set the coordinates manually.
 
 ## Support Information
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,7 @@ retry_files_enabled = False
 inventory = inventory/base_inventory, inventory/keyed_groups_stage_1.config, inventory/keyed_groups_stage_2.config
 interpreter_python = auto_silent
 stdout_callback = debug
+jinja2_extensions = jinja2.ext.do
 
 #needed for software upgrade
 [persistent_connection]

--- a/example.env
+++ b/example.env
@@ -1,0 +1,2 @@
+FF_WIKI_PASSWORD=password
+FF_WIKI_USER=username

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ jmespath >= 1.0.1
 netaddr >= 0.8.0
 yamllint >= 1.30.0
 ansible-lint >= 6.14.3
+requests >= 2.29.0
+python-dotenv >= 1.0.0

--- a/roles/cfg_openwrt/files/wiki/update.py
+++ b/roles/cfg_openwrt/files/wiki/update.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import re
+
+import requests
+from dotenv import load_dotenv
+
+"""
+This script was derived from the edit_section.py script from the
+freifunk-berlin repo https://github.com/freifunk-berlin/falter-wiki-bot.
+"""
+
+############
+#  CONFIG  #
+############
+
+load_dotenv(".env")
+
+API_URL = "https://wiki.freifunk.net/api.php"
+WIKI_URL = "https://wiki.freifunk.net"
+INTRO = (
+    "<b>Diesen Abschnitt nicht bearbeiten. Änderungen werden automatisch überschrieben!</b>"
+    "<br> Die Konfiguration für diesen Standort wurde mit dem Tool"
+    "[https://github.com/freifunk-berlin/bbb-configs bbb-configs] erstellt."
+    "Der aktuelle Stand der Konfiguration kann dort eingesehen werden."
+    "Teile des Wikiartikels werden mit Hilfe von Semantic Values und Templates automatisch erstellt."
+)
+
+# (Sub)-String that marks a auto-generated bbb-configs section
+SECTION_REGEX = "Konfiguration"
+s = requests.Session()
+
+################
+#  FUNCTIOINS  #
+################
+
+
+def find_wiki_page(node: str):
+    query = (
+        f"{API_URL}?action=ask&query=[[Hat_Knoten%3A%3A{node}]]"
+        "|%3FModification date|sort%3DModification date|order%3Ddesc&format=json"
+    )
+    response = s.get(url=query).json()
+    print(response)
+    results = response.get("query").get("results")
+
+    if len(results) == 0:
+        raise ValueError(f"No Wiki article found for the given node name: {node}")
+        exit(1)
+
+    return list(results.values())[0].get("fulltext")
+
+
+# queries the article and looks for the number of the section
+# containing the auto-generated configuration
+def find_bbbconfigs_section(pagetitle: str):
+    params = {"action": "parse", "page": pagetitle, "format": "json"}
+    response = s.get(url=API_URL, params=params).json()
+
+    sections = response.get("parse").get("sections")
+
+    # iterate over sections and find bbb-config section
+    bbb_configs_section = -1
+    bbb_configs_section_title = ""
+    for sec in sections:
+        sec_title = sec.get("line")
+        if re.search(SECTION_REGEX, sec_title):
+            bbb_configs_section = sec["index"]
+            bbb_configs_section_title = sec_title
+            break
+
+    if bbb_configs_section != -1:
+        return {"index": bbb_configs_section, "title": bbb_configs_section_title}
+    else:
+        raise ValueError(
+            (
+                "Theres no Konfiguration-section in the given article! See instructions at"
+                "https://github.com/freifunk-berlin/bbb-configs#automaticly-updating-to-wikifreifunknet"
+            )
+        )
+
+
+def get_login_token():
+    # Get login token for API calls
+    param_login_query = {
+        "action": "query",
+        "meta": "tokens",
+        "type": "login",
+        "format": "json",
+    }
+
+    r = s.get(url=API_URL, params=param_login_query)
+    data = r.json()
+    return data["query"]["tokens"]["logintoken"]
+
+
+def login_at_api(login_token):
+    # Send a post request to login.
+    params_login = {
+        "action": "login",
+        "lgname": os.getenv("FF_WIKI_USER"),
+        "lgpassword": os.getenv("FF_WIKI_PASSWORD"),
+        "lgtoken": login_token,
+        "format": "json",
+    }
+
+    s.get(url=API_URL, params=params_login)
+
+
+def fetch_csrf_token():
+    # GET request to fetch CSRF token
+    params_csrf = {"action": "query", "meta": "tokens", "format": "json"}
+
+    r = s.get(url=API_URL, params=params_csrf)
+    data = r.json()
+
+    return data["query"]["tokens"]["csrftoken"]
+
+
+def edit_section(article_title, section_number, csrf_token, new_text):
+    # POST request to edit specific section in a page
+    params_edit = {
+        "action": "edit",
+        "title": article_title,
+        "section": section_number,  # 0=Introduction, 1=first_section, etc.
+        "token": csrf_token,
+        "bot": True,
+        # "minor": True,
+        "format": "json",
+        "text": new_text,
+        "summary": "Automatisches Update aus bbb-configs.",
+    }
+
+    r = s.post(API_URL, data=params_edit)
+    data = r.json()
+
+    if data.get("error"):
+        raise ValueError(data.get("error").get("info"))
+        exit(1)
+    if data.get("edit").get("nochange") == "":
+        print(
+            (
+                "SKIPPED: The Wiki article was already up to date."
+                "No changes were made. See: {WIKI_URL}/{data.get('edit').get('title')}"
+            )
+        )
+    else:
+        print(
+            (
+                "UPDATED: The wiki article was successfully updated."
+                "Check the results at: {WIKI_URL}/{data.get('edit').get('title')}"
+            )
+        )
+
+
+if __name__ == "__main__":
+    #####################
+    #  ARGUMENT PARSER  #
+    #####################
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-n", "--node", help="node whose wiki article should be edited.", required=True
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--text", help="String which should be posted into section.")
+    group.add_argument("-f", "--file", help="Read text from a file")
+    args = parser.parse_args()
+
+    ########################
+    #  Paste text to Wiki  #
+    ########################
+
+    pagetitle = find_wiki_page(args.node)
+    section = find_bbbconfigs_section(pagetitle)
+
+    pagetxt = f"== {section['title']} ==\n\n"  # Text that gets posted into the specific article section
+    pagetxt += f"{INTRO}\n\n"
+
+    if args.text:
+        pagetxt += args.text
+    else:
+        pagetxt += open(args.file, "r").read()
+
+    login_token = get_login_token()
+    login_at_api(login_token)
+    csrf_token = fetch_csrf_token()
+
+    edit_section(pagetitle, section["index"], csrf_token, pagetxt)
+
+    s.close()

--- a/roles/cfg_openwrt/tasks/main.yml
+++ b/roles/cfg_openwrt/tasks/main.yml
@@ -24,6 +24,7 @@
     imagebuilder_dir: "{{ basedir }}/imagebuilders/"
     imagebuild_dir: "{{ basedir }}/tmp/imagebuild/{{ inventory_hostname }}"
     image_dir: "{{ basedir }}/images/"
+    wikiupdater_dir: "{{ basedir }}/wikiupdater/"
   tags: always
 
 - name: Create directory
@@ -98,3 +99,19 @@
     - never
     - flash
   when: ipv6_prefix is defined
+
+- name: Include wikiupdater
+  include_tasks:
+    file: wikiupdater.yml
+    apply:
+      tags: wiki
+  tags: wiki
+  when: role == "corerouter"
+
+- name: Wikiupdaterinfo
+  ansible.builtin.debug:
+    msg:
+      - Role from your current device is {{ role }}. Wikiupdater needs to be run with the Corerouter.
+      - You might need to change your limit to include the core-router if you dont get the desired output.
+  tags: wiki
+  when: role != "corerouter"

--- a/roles/cfg_openwrt/tasks/wikiupdater.yml
+++ b/roles/cfg_openwrt/tasks/wikiupdater.yml
@@ -1,0 +1,23 @@
+---
+- name: wikiupdater | Generate directory
+  file:
+    path: "{{ wikiupdater_dir }}"
+    state: directory
+    mode: "731"
+
+- name: wikiupdater | Generate outputfiles
+  template:
+    src: "templates/common/wikiupdater.j2"
+    dest: "{{ wikiupdater_dir }}/{{ group_names[0] | split('_') | last }}.txt"
+    mode: "644"
+
+- name: wikiupdater | Update article
+  script: ../files/wiki/update.py -n "{{ inventory_hostname }}"  --file "{{ wikiupdater_dir }}/{{ group_names[0] | split('_') | last }}.txt"
+  register: wiki_res
+  changed_when: '"UPDATED" in wiki_res.stdout'
+  args:
+    executable: python3
+
+- name: wikiupdater | Print response
+  debug:
+    msg: "{{ wiki_res.stdout }}"

--- a/roles/cfg_openwrt/templates/common/wikiupdater.j2
+++ b/roles/cfg_openwrt/templates/common/wikiupdater.j2
@@ -1,0 +1,129 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+
+{# Printing files in semantic mediawiki syntax for wiki.freifunk.net #}
+
+{# wi.ki is a namespacevariable containing everything that should be printed #}
+{% set wi = namespace(ki={})%}
+{% do wi.ki.update({
+    'Mesh Adressen':[],
+    'Mesh Liste':[],
+    'Mesh Anzahl':0
+    })%}
+
+{# attributes is a list of vars that can be directly printed without any magic #}
+{% set attributes = [
+    'location_nice',
+    'latitude',
+    'longitude',
+    'ipv6_prefix'
+    ]%}
+{% for i in attributes %}
+    {% do wi.ki.update( {i: lookup('vars', i|string, default='')}) %}
+{% endfor %}
+
+{# Processing vars from general.yml #}
+{# Big chunks from this part are copied from config/freifunk.j2 #}
+
+ {% if community is true and contact_name is undefined %}
+    {% do wi.ki.update({'Ansprechpartner Name': 'Freifunk Engenieering Task Force'}) %}
+{% elif contact_name is defined %}
+    {% do wi.ki.update({'Ansprechpartner Name': contact_name})%}
+{% endif %}
+{% if community is true and contact_nickname is undefined %}
+    {% do wi.ki.update({'Ansprechpartner Nickname': 'FETF'})%}
+{% elif contact_nickname is defined %}
+    {% do wi.ki.update({'Ansprechpartner Nickname': contact_nickname})%}
+{% endif %}
+{% if contacts is defined%}
+    {# Check if Contact is a Matrixroom because the wiki interprets #foo:matrix.org as a URI fragment #}
+    {% set contacts_output = [] %}
+    {% for contact in contacts %}
+        {% if (contact | regex_search('^#.*\:.*\..*')) %}
+            {% do contacts_output.append('https://matrix.to/'+contact) %}
+        {% else %}
+            {% do contacts_output.append(contact) %}
+        {% endif %}
+    {% endfor %}
+    {% do wi.ki.update({'Ansprechpartner Kontakt': contacts_output})%}
+{% else %}
+    {% do wi.ki.update({'Ansprechpartner Kontakt': 'info'+location+'@berlin.freifunk.net'})%}
+{% endif %}
+
+{# Processing vars from network.yml #}
+
+{% for network in networks %}
+    {% if network['role'] == 'mesh' %}
+        {# Formatting the variables already in a list that can be easily used in semantic mediawiki #}
+        {% do wi.ki['Mesh Liste'].append(network['vid']~'('~network['name']~')')|default([])%}
+        {% do wi.ki['Mesh Adressen'].append(network['prefix'])%}
+        {% do wi.ki.update({'Mesh Anzahl': wi.ki['Mesh Anzahl'] + 1 }) %}
+    {% elif network['role'] == 'ext' %}
+        {% do wi.ki.update({'Wireguard Tunnel': network['tunnel_connections']})%}
+        {% do wi.ki['Mesh Adressen'].append(network['tunnel_mesh_prefix_ipv4'])%}
+        {# Currently, the only automated way I can say with some certainty that the site is connected to the BBB is with Wireguard #}
+        {% do wi.ki.update({'BBB': true })%}
+    {% elif network['role'] == 'mgmt'%}
+        {% do wi.ki.update({'Managementnetwork': network['prefix']})%}
+        {# Subobjects are like a list of dictionaries at the level of pages of Semantic Mediawiki #}
+        {% do wi.ki.update({'subobjects': {} })%}
+        {% for assigned in network['assignments']%} {# uses the list of mgmt-network-assignments to loop thru all devices #}
+            {% set subobject = {} %}
+            {% do subobject.update({'name':assigned})%}
+            {% do subobject.update({'IPv4': network['prefix'] | ansible.utils.ipaddr(network['assignments'][assigned]) | ansible.utils.ipaddr('address') }) %}
+            {% if hostvars[assigned] is defined %} {# Only devices with OpenWRT-Images get channels assigned by Ansible. #}
+                {# Getting Role, Model and Target for Devices #}
+                {% for property in ['role', 'model', 'target']%}
+                    {% for properties in groups | select('match', property~'_.*')%}
+                        {% if assigned in groups[properties] %}
+                            {% do subobject.update({property: properties.replace(property~'_','')}) %}
+                        {% endif %}
+                    {% endfor %}
+                {% endfor%}
+            {% endif %}
+            {% do wi.ki['subobjects'].update({assigned : subobject})%}
+        {% endfor %}
+    {% elif network['role'] == 'dhcp'%}
+        {# Doing it this way to account for different dhcp-networks like private ones (brdhcp) #}
+        {% do wi.ki.update({(network['name']|default('dhcp'))~'network': network['prefix']})%}
+    {% endif %}
+{% endfor %}
+
+{# Printing wi.ki #}
+
+{# Makro for handling the print of lists#}
+{% macro print(key,value)%}
+    {% if value|type_debug == 'list'-%}
+        {% for i in value -%}
+            |{{key}} = {{i}}
+        {% endfor %}
+    {% else -%}
+        |{{key}} = {{value}}
+    {% endif %}
+{% endmacro %}
+
+{% raw %}{{#set:{% endraw %}
+
+{% for i in wi.ki %}
+    {% if not i == 'subobjects' -%}
+        {{ print(i, wi.ki[i])}}
+    {% endif %}
+{% endfor %}
+{% raw %} }} {% endraw %}
+
+{% if 'subobjects' in wi.ki %}
+    {% for i in wi.ki['subobjects'] %}
+        {% raw %} {{#subobject: {% endraw %}{{i}}
+        {% for n in wi.ki['subobjects'][i]%}
+            {{ print(n, wi.ki['subobjects'][i][n])}}
+        {% endfor %}
+        {% raw %} }} {% endraw %}
+    {% endfor %}
+{% endif %}
+
+{# Setting categories #}
+
+{% raw %} [[Kategorie:Berlin]] {% endraw %}
+{% if wi.ki['BBB'] is true %}
+    {% raw %} [[Kategorie:BBB]] {% endraw %}
+{% endif %}
+{% raw %} [[Kategorie:Standorte_Berlin|{% endraw %}{{location}}{% raw %}]]{% endraw %}


### PR DESCRIPTION
The goal is to have a tool that updates the wiki since it is often outdatet in comparison to bbb-configs. @Akira25 already wrote a [script](https://github.com/freifunk-berlin/falter-wiki-bot)  to push changes into the wiki. This is still an early draft. It still needs to be discussed which the community if and how an automation coud make sense.

While testing the script we found several locations using a non network adress as a network adress. It still needs to be investigated whether my changes would affect the assigned adresses.

The conecept right now is to extract all relevant data from the yml-files, convert them into the format of the semantic properties from the wiki and than have in every wikipage that should be updatet a section with all the values hidden. We can than point in the article to these values and just update the values without touching the articles. This enables a big flexibility. It would also make it possible to extract these data from the wiki. [Here](https://wiki.freifunk.net/Spezial:Durchsuchen?title=Spezial%3ADurchsuchen&article=Berlin%3AStandorte%3ASamariterkirche) is an example from Sama for the semantic properties.