### PR TITLE
Adding Makefile for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+lint: deps
+	yamllint -d .config/yaml-lint.yml .
+	ansible-lint -c .config/ansible-lint.yml
+
+configs: deps lint
+	time ansible-playbook play.yml
+
+deps:
+	pip3 install -q -r requirements.txt


### PR DESCRIPTION
To make it easier to run some checks before pushing i added a makefile. You can use it with `make lint`, `make configs` or `make deps`. These are the same checks that run in github automaticly with each PR. Although it is possible to do checks with generate-images.sh i found this way more convenient. Thanks to @pktpls for providing this solution.