### PR TITLE
corerouter: instead of domains use hostrecords

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -20,9 +20,9 @@ config dnsmasq
 
 {% for network in networks | selectattr('role', 'equalto', 'mgmt') %}
   {% for host, ip_num in network['assignments'].items() %}
-config domain '{{ host | replace('-', '_') }}_olsr'
-	option name '{{ host }}.olsr'
-	option ip '{{ network['prefix'] | ansible.utils.ipaddr(ip_num) | ansible.utils.ipaddr('address') }}'
+config hostrecord
+	list name '{{ host }}.olsr'
+	list ip '{{ network['prefix'] | ansible.utils.ipaddr(ip_num) | ansible.utils.ipaddr('address') }}'
 
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
We actually talk about hosts and not domains. So lets switch to hostrecords.