### PR TITLE
MT7915E: switch to snapshot

### DIFF
--- a/group_vars/model_netgear_wax202.yml
+++ b/group_vars/model_netgear_wax202.yml
@@ -1,6 +1,8 @@
 ---
 target: ramips/mt7621
 
+openwrt_version: snapshot
+
 dsa_ports:
   - wan
   - lan1

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -1,6 +1,8 @@
 ---
 target: ramips/mt7621
 
+openwrt_version: snapshot
+
 dsa_ports:
   - lan
 


### PR DESCRIPTION
Snapshot uses the newer 5.15 Linux kernel. By switching the devices to snapshot the issues with unstable mesh connections are now gone.

Note: I did not include the ZyXEL NWA50AX into this commit, as it is seems to be used only as AP, however it will need to be switched to snapshot if someone wants to use it for meshing.