### PR TITLE
rhnk: update definitions to match current deployment

### DIFF
--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -26,18 +26,18 @@ networks:
     mesh_metric: 128
     ptp: true
 
-  - vid: 12
-    role: mesh
-    name: mesh_philmel60
-    prefix: 10.230.3.12/32
-    ipv6_subprefix: -12
-    ptp: true
-
   - vid: 13
     role: mesh
     name: mesh_richardplatz
     prefix: 10.230.3.13/32
     ipv6_subprefix: -13
+    ptp: true
+
+  - vid: 14
+    role: mesh
+    name: mesh_klunker60
+    prefix: 10.230.3.14/32
+    ipv6_subprefix: -14
     ptp: true
 
   - vid: 15
@@ -150,10 +150,10 @@ networks:
       rhnk-rhxb: 11
 
       # Mikrotik Cube 60 Pro (dead)
-      rhnk-philmel-60ghz: 12
-
-      # Mikrotik Cube 60 Pro (dead)
       rhnk-richardplatz: 13
+
+      # Mikrotik Cube 60 Pro, RouterOS 7.7
+      rhnk-klunker-60ghz: 14
 
       # Powerbeam 5AC 400 ISO, AirOS 8.7.11
       rhnk-emma: 15

--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -105,13 +105,6 @@ networks:
     mesh_iface: mesh
 
   # TODO: change me so i match the IP address
-  - vid: 31
-    role: mesh
-    name: mesh_nf_nw
-    prefix: 10.230.3.27/32
-    ipv6_subprefix: -31
-
-  # TODO: change me so i match the IP address
   - vid: 32
     role: mesh
     name: mesh_nf_no
@@ -178,9 +171,6 @@ networks:
 
       # Rocket 5AC Lite - AirOS 8.7.11
       rhnk-nno-5ghz: 25
-
-      # SXTsq 5 ac - OpenWrt - dead
-      rhnk-nf-nw-5ghz: 27
 
       # SXTsq 5 ac - OpenWrt
       rhnk-nf-no-5ghz: 28

--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -63,7 +63,7 @@ networks:
 
   - vid: 22
     role: mesh
-    name: mesh_ono_5
+    name: mesh_wsw_60
     prefix: 10.230.3.22/32
     ipv6_subprefix: -22
 
@@ -163,6 +163,9 @@ networks:
 
       # Rocket 5AC Lite, AirOS 8.7.0
       rhnk-wsw-5ghz: 21
+
+      # Wave AP, firmware 3.1.1
+      rhnk-wsw-60ghz: 22
 
       # Rocket 5AC Lite, AirOS 8.7.11
       rhnk-ssw-5ghz: 23

--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -103,6 +103,27 @@ networks:
     mesh_radio: 11a_standard
     mesh_iface: mesh
 
+  # TODO: change me so i match the IP address
+  - vid: 31
+    role: mesh
+    name: mesh_nf_nw
+    prefix: 10.230.3.27/32
+    ipv6_subprefix: -31
+
+  # TODO: change me so i match the IP address
+  - vid: 32
+    role: mesh
+    name: mesh_nf_no
+    prefix: 10.230.3.28/32
+    ipv6_subprefix: -32
+
+  # TODO: change me so i match the IP address
+  - vid: 33
+    role: mesh
+    name: mesh_nf_so
+    prefix: 10.230.3.29/32
+    ipv6_subprefix: -33
+
   - vid: 40
     role: dhcp
     prefix: 10.230.3.64/26
@@ -152,7 +173,15 @@ networks:
       # Rocket 5AC Lite
       rhnk-nno-5ghz: 25
 
+      # SXTsq 5 ac, OpenWrt (dead)
       rhnk-nf-nw-5ghz: 27
+
+      # SXTsq 5 ac, OpenWrt
       rhnk-nf-no-5ghz: 28
+
+      # SXTsq 5 ac, OpenWrt
       rhnk-nf-so-5ghz: 29
+
+      # EAP225-Outdoor, OpenWrt, with UMA-D antenna
+      # TODO: set explicit txpower to account for increased antenna gain
       rhnk-nf-bvv: 30

--- a/group_vars/location_rhnk/networks.yml
+++ b/group_vars/location_rhnk/networks.yml
@@ -94,6 +94,7 @@ networks:
     mesh_radio: 11g_standard
     mesh_iface: mesh
 
+  # TODO: remove me, rhnk-bvv link is only 2ghz
   - vid: 30
     role: mesh
     name: mesh_nf_bvv
@@ -141,50 +142,52 @@ networks:
     ipv6_subprefix: 1
     assignments:
       rhnk-core: 1
+
+      # Mikrotik CRS328-24P-4S+RM - SwitchOS 2.13
       rhnk-switch: 2
 
-      # AirFiber 60-LR, firmware v2.6.0
+      # AirFiber 60-LR - firmware v2.6.0
       rhnk-philmel: 10
 
-      # AirFiber 60-LR, firmware v2.6.0
+      # AirFiber 60-LR - firmware v2.6.0
       rhnk-rhxb: 11
 
-      # Mikrotik Cube 60 Pro (dead)
+      # Mikrotik Cube 60 Pro - RouterOS 7.7
       rhnk-richardplatz: 13
 
-      # Mikrotik Cube 60 Pro, RouterOS 7.7
+      # Mikrotik Cube 60 Pro - RouterOS 7.7
       rhnk-klunker-60ghz: 14
 
-      # Powerbeam 5AC 400 ISO, AirOS 8.7.11
+      # Powerbeam 5AC 400 ISO - AirOS 8.7.11
       rhnk-emma: 15
 
-      # Rocket 5AC Lite, AirOS 8.7.11
+      # Rocket 5AC Lite - AirOS 8.7.11
       rhnk-no-5ghz: 20
 
-      # Rocket 5AC Lite, AirOS 8.7.0
+      # Rocket 5AC Lite - AirOS 8.7.11
       rhnk-wsw-5ghz: 21
 
-      # Wave AP, firmware 3.1.1
+      # Wave AP - firmware 3.1.1
       rhnk-wsw-60ghz: 22
 
-      # Rocket 5AC Lite, AirOS 8.7.11
+      # Rocket 5AC Lite - AirOS 8.7.11
       rhnk-ssw-5ghz: 23
 
-      # Wave AP, firmware 3.1.0-beta
+      # Wave AP - firmware 3.1.0-rc
       rhnk-oso-60ghz: 24
 
-      # Rocket 5AC Lite
+      # Rocket 5AC Lite - AirOS 8.7.11
       rhnk-nno-5ghz: 25
 
-      # SXTsq 5 ac, OpenWrt (dead)
+      # SXTsq 5 ac - OpenWrt - dead
       rhnk-nf-nw-5ghz: 27
 
-      # SXTsq 5 ac, OpenWrt
+      # SXTsq 5 ac - OpenWrt
       rhnk-nf-no-5ghz: 28
 
-      # SXTsq 5 ac, OpenWrt
+      # SXTsq 5 ac - OpenWrt
       rhnk-nf-so-5ghz: 29
 
-      # EAP225-Outdoor, OpenWrt, with UMA-D antenna
+      # EAP225-Outdoor - OpenWrt - with UMA-D antenna
       # TODO: set explicit txpower to account for increased antenna gain
       rhnk-nf-bvv: 30

--- a/host_vars/rhnk-nf-no-5ghz/base.yml
+++ b/host_vars/rhnk-nf-no-5ghz/base.yml
@@ -5,4 +5,4 @@ role: ap
 model: "mikrotik_sxtsq-5-ac"  # this host is revision 2 of the device
 
 mac_override:
-  eth0: 2C:C8:1B:6B:E7:31
+  eth0: 2c:c8:1b:6a:9a:2c

--- a/host_vars/rhnk-nf-nw-5ghz/base.yml
+++ b/host_vars/rhnk-nf-nw-5ghz/base.yml
@@ -1,8 +1,0 @@
----
-
-location: rhnk
-role: ap
-model: "mikrotik_sxtsq-5-ac"
-
-mac_override:
-  eth0: 2c:c8:1b:8a:96:0c

--- a/host_vars/rhnk-nf-nw-5ghz/base.yml
+++ b/host_vars/rhnk-nf-nw-5ghz/base.yml
@@ -5,4 +5,4 @@ role: ap
 model: "mikrotik_sxtsq-5-ac"
 
 mac_override:
-  eth0: 2C:C8:1B:8A:96:0C
+  eth0: 2c:c8:1b:8a:96:0c

--- a/host_vars/rhnk-nf-so-5ghz/base.yml
+++ b/host_vars/rhnk-nf-so-5ghz/base.yml
@@ -5,4 +5,4 @@ role: ap
 model: "mikrotik_sxtsq-5-ac"  # this host is revision 2 of the device
 
 mac_override:
-  eth0: 2C:C8:1B:6A:9A:2C
+  eth0: 2c:c8:1b:6b:e7:31


### PR DESCRIPTION
- rhnk: rename APs and start to use them
- rhnk: add 60ghz klunkerkranich link, remove old test link
- rhnk: add wsw-60ghz sector for ak36
- rhnk: add some more notes and todos