### PR TITLE
fritzbox7530: add dsa variant for snapshot

### DIFF
--- a/group_vars/model_avm_fritzbox_7530.yml
+++ b/group_vars/model_avm_fritzbox_7530.yml
@@ -5,10 +5,8 @@ model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"
   - "kmod-ath10k ath10k-firmware-qca4019"
 
-switch_ports: 6
+switch_ports: 5
 switch_int_port: 0
-switch_ignore_ports: [5]
-# WAN port is hardwired to VLAN2. ignore
 
 int_port: eth0
 

--- a/group_vars/model_avm_fritzbox_7530_dsa.yml
+++ b/group_vars/model_avm_fritzbox_7530_dsa.yml
@@ -1,0 +1,26 @@
+---
+openwrt_version: snapshot
+target: ipq40xx/generic
+override_target: "avm_fritzbox-7530"
+
+model__packages__to_merge:
+  - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"
+  - "kmod-ath10k ath10k-firmware-qca4019"
+
+dsa_ports:
+  - lan1
+  - lan2
+  - lan3
+  - lan4
+
+wireless_devices:
+  - name: 11a_standard
+    band: 5g
+    htmode_prefix: VHT
+    path: platform/soc/a800000.wifi
+    ifname_hint: wlan5
+  - name: 11g_standard
+    band: 2g
+    htmode_prefix: HT
+    path: platform/soc/a000000.wifi
+    ifname_hint: wlan2


### PR DESCRIPTION
DSA conversion is neccessary to run OpenWrt snapshot so that we can test the VDSL modem.

Switch your host's `model` to `avm_fritzbox-7530_dsa` to try it out.