### PR TITLE
wuhli: fix non existing freifunk_legacy wireless profile

### DIFF
--- a/host_vars/wuhli-core/base.yml
+++ b/host_vars/wuhli-core/base.yml
@@ -4,4 +4,4 @@ location: wuhli
 role: corerouter
 model: "tplink_tl-wdr4900-v1"
 
-wireless_profile: freifunk_legacy
+wireless_profile: freifunk_default

--- a/host_vars/wuhli-n-nf-5ghz/base.yml
+++ b/host_vars/wuhli-n-nf-5ghz/base.yml
@@ -3,7 +3,6 @@
 location: wuhli
 role: ap
 model: "mikrotik_sxtsq-5-ac"
-wireless_profile: freifunk_legacy
 
 mac_override:
   eth0: 2c:c8:1b:8a:95:72

--- a/host_vars/wuhli-o-nf-5ghz/base.yml
+++ b/host_vars/wuhli-o-nf-5ghz/base.yml
@@ -3,7 +3,6 @@
 location: wuhli
 role: ap
 model: "mikrotik_sxtsq-5-ac"
-wireless_profile: freifunk_legacy
 
 mac_override:
   eth0: 2c:c8:1b:8a:96:9c

--- a/host_vars/wuhli-s-nf-5ghz/base.yml
+++ b/host_vars/wuhli-s-nf-5ghz/base.yml
@@ -3,7 +3,6 @@
 location: wuhli
 role: ap
 model: "mikrotik_sxtsq-5-ac"
-wireless_profile: freifunk_legacy
 
 mac_override:
   eth0: 2c:c8:1b:8a:95:a6

--- a/host_vars/wuhli-w-nf-5ghz/base.yml
+++ b/host_vars/wuhli-w-nf-5ghz/base.yml
@@ -3,7 +3,6 @@
 location: wuhli
 role: ap
 model: "mikrotik_sxtsq-5-ac"
-wireless_profile: freifunk_legacy
 
 mac_override:
   eth0: 2c:c8:1b:8a:95:b4


### PR DESCRIPTION
freifunk_legacy was removed due to owe revert.