### PR TITLE
Added defaults for switch_ignore_ports

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -19,13 +19,13 @@ These files define how bbb-configs needs to handle different hardware models. Th
 
 ```yml
 ---
-target: "ipq40xx/generic"       # target of router model
+target: "ipq40xx/generic"               # target of router model
 
-switch_ports: 6             # number of physical ports + one (CPU)
-switch_int_port: 0          # port-id of the CPU
-switch_ignore_ports: []     # omit ports, that exist in software but not in hardware (i.e. MikroTik SXTsq 5ac)
+switch_ports: 6                         # number of physical ports + one (CPU)
+switch_int_port: 0                      # port-id of the CPU
+switch_ignore_ports: [1, 2, 3, 4]       # omit ports, that exist in software but not in hardware (i.e. MikroTik SXTsq 5ac)
 
-int_port: eth0              # hardware-device on which swconfig works on
+int_port: eth0                          # hardware-device on which swconfig works on
 
 wireless_devices:                       # definitions for the devices radios
   - name: 11a_standard                  # 5GHz radio

--- a/group_vars/model_tplink_tl_wdr3500_v1.yml
+++ b/group_vars/model_tplink_tl_wdr3500_v1.yml
@@ -3,7 +3,6 @@ target: ath79/generic
 
 switch_ports: 5
 switch_int_port: 0
-switch_ignore_ports: []
 
 int_port: eth0
 

--- a/group_vars/model_tplink_tl_wdr3600_v1.yml
+++ b/group_vars/model_tplink_tl_wdr3600_v1.yml
@@ -3,7 +3,6 @@ target: ath79/generic
 
 switch_ports: 6
 switch_int_port: 0
-switch_ignore_ports: []
 
 int_port: eth0
 

--- a/group_vars/model_tplink_tl_wdr4300_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4300_v1.yml
@@ -3,7 +3,6 @@ target: ath79/generic
 
 switch_ports: 6
 switch_int_port: 0
-switch_ignore_ports: []
 
 int_port: eth0
 

--- a/group_vars/model_tplink_tl_wdr4900_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4900_v1.yml
@@ -3,8 +3,6 @@ target: mpc85xx/p1010
 
 switch_ports: 6
 switch_int_port: 0
-switch_ignore_ports: []
-
 int_port: eth0
 
 wireless_devices:

--- a/roles/cfg_openwrt/templates/common/config/swconfig.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/swconfig.network.inc
@@ -8,7 +8,7 @@ config switch
 
   {% for network in networks %}
     {% set portmapping = [] %}
-    {% for port in range(switch_ports)|list|difference(switch_ignore_ports) %}
+    {% for port in range(switch_ports)|list|difference(switch_ignore_ports|default([])) %}
       {% set tagged = not network.get('untagged') or port == switch_int_port %}
       {{ portmapping.append(port|string + ("t" if tagged else "")) }}
     {%- endfor %}


### PR DESCRIPTION
Empty switch_ignore_ports-lists are no longer required in the model files. Removed it from the existing model-files and updated docs.