### PR TITLE
scharni: increase babeld metric to 2048 to prefer zwingli

### DIFF
--- a/group_vars/location_scharni/networks.yml
+++ b/group_vars/location_scharni/networks.yml
@@ -8,7 +8,7 @@ networks:
     prefix: 10.31.252.192/32
     ipv6_subprefix: -2
     # prefer zwingli uplink because it provides better performance
-    mesh_metric: 1024
+    mesh_metric: 2048
     mesh_metric_lqm: ['default 0.5']
     ptp: true
 


### PR DESCRIPTION
1024 as metric is not enough to route the traffic via zwingli.