### PR TITLE
philmel: changed naming due to new link direction on 60GHz directing …

### DIFF
--- a/group_vars/location_philmel/networks.yml
+++ b/group_vars/location_philmel/networks.yml
@@ -75,11 +75,11 @@ networks:
     ipv6_subprefix: -8
     ptp: true
     mesh_metric: 1024
-    mesh_metric_lqm: ['default 0.3']  # prefer rhnk link
+    mesh_metric_lqm: ['default 0.3']  # prefer klunker link
 
   - vid: 18
     role: mesh
-    name: mesh_rhnk
+    name: mesh_klunker
     prefix: 10.230.2.25/32
     ipv6_subprefix: -9
     ptp: true
@@ -103,7 +103,7 @@ networks:
       philmel-core: 1
       philmel-switch-1: 2
       philmel-switch-2: 3
-      philmel-rhnk: 4
+      philmel-klunker: 4
       philmel-no-5ghz: 5
       philmel-nw-5ghz: 6
       philmel-ost-legacy: 7


### PR DESCRIPTION
…north

This is only a name change in 60GHz link directing north. It was the former link between rhnk and philmel and is now the link between klunkerkranich and philmel. These changes improved the link stability