### PR TITLE
vaterhaus: add network for hosting services

### DIFF
--- a/group_vars/all/wireless_profiles.yml
+++ b/group_vars/all/wireless_profiles.yml
@@ -355,6 +355,49 @@ wireless_profiles:
         mesh_fwding: 0
         ifname_hint: mesh
 
+  - name: vaterhaus
+    devices:
+      - radio: 11a_standard
+        legacy_rates: false
+        country: DE
+      - radio: 11g_standard
+        legacy_rates: false
+        country: DE
+      - radio: 11a_mesh
+        legacy_rates: false
+        country: DE
+
+    ifaces:
+      - mode: ap
+        ssid: berlin.freifunk.net
+        encryption: none
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ff
+
+      - mode: ap
+        ssid: berlin.freifunk.net Encrypted
+        encryption: owe
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ffowe
+        ieee80211w: 1
+
+      - mode: mesh
+        mesh_id: Mesh-Freifunk-Berlin
+        radio: [11a_standard, 11g_standard, 11a_mesh]
+        mcast_rate: 12000
+        mesh_fwding: 0
+        ifname_hint: mesh
+
+      - mode: ap
+        ssid: Freifunk-Services
+        encryption: sae-mixed
+        key: 'file:/root/wifi_pass'
+        network: services
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: srv
+
 all__channel_assignments_11a_standard__to_merge:
   default: "36-20"
 

--- a/group_vars/location_vaterhaus/networks.yml
+++ b/group_vars/location_vaterhaus/networks.yml
@@ -6,6 +6,7 @@ ipv6_prefix: "2001:bf7:830:a500::/56"
 # --MGMT: 10.230.192.192/27
 # --MESH: 10.230.192.224/27 {as /32}
 # --DHCP: 10.31.155.0/26
+# --DHCP: 10.31.196.80/29 (Private DHCP-Network to host services)
 #
 # The Edgeswitch 10.230.192.194 has a ping-watchdog on the core router on Port 1 - POE Ping Watchdog 10 min 8.8.8.8
 
@@ -71,6 +72,16 @@ networks:
     ipv6_subprefix: 0
     assignments:
       vaterhaus-core: 1
+
+  # DHCP without filtering and isolation to host services
+  - vid: 41
+    role: dhcp
+    name: services
+    prefix: 10.31.196.80/29
+    ipv6_subprefix: 2
+    assignments:
+      vaterhaus-core: 1
+      vaterhaus-meshtastic: 2
 
   - vid: 42
     role: mgmt

--- a/group_vars/location_vaterhaus/ssh-keys.yml
+++ b/group_vars/location_vaterhaus/ssh-keys.yml
@@ -1,0 +1,4 @@
+---
+location__ssh_keys__to_merge:
+  - comment: Noki
+    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPjIgJKflHEYOIdskwalr83PflhPmFkrAebP2bUkOE11 Noki

--- a/host_vars/vaterhaus-n-nf-2ghz/base.yml
+++ b/host_vars/vaterhaus-n-nf-2ghz/base.yml
@@ -5,3 +5,5 @@ role: ap
 model: "ubnt_nanostation-m2_xm"
 
 poe_on: []
+
+wireless_profile: vaterhaus


### PR DESCRIPTION
This adds a new wifi network to host services on Vaterhaus.