### PR TITLE
Start using 23.05

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -1,6 +1,6 @@
 ---
 # default OpenWRT version to build from unless overridden
-openwrt_version: 22.03-SNAPSHOT
+openwrt_version: 23.05-SNAPSHOT
 imagebuilder_filename: "openwrt-imagebuilder-{{ openwrt_version ~ '-' if openwrt_version != 'snapshot' else '' }}{{ target | replace('/','-') }}.Linux-x86_64.tar.xz"
 imagebuilder: "https://downloads.cdn.openwrt.org/{{ 'snapshots' if openwrt_version == 'snapshot' else 'releases/' ~ openwrt_version }}/targets/{{ target }}/{{ imagebuilder_filename }}"
 feed: "src/gz openwrt_falter https://firmware.berlin.freifunk.net/feed/__FEED_VERSION__/packages/__INSTR_SET__/falter"

--- a/group_vars/model_avm_fritzbox_4040.yml
+++ b/group_vars/model_avm_fritzbox_4040.yml
@@ -1,5 +1,6 @@
 ---
 target: ipq40xx/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_avm_fritzbox_4040_dsa.yml
+++ b/group_vars/model_avm_fritzbox_4040_dsa.yml
@@ -1,5 +1,4 @@
 ---
-openwrt_version: snapshot
 target: ipq40xx/generic
 override_target: "avm_fritzbox-4040"
 

--- a/group_vars/model_avm_fritzbox_7530.yml
+++ b/group_vars/model_avm_fritzbox_7530.yml
@@ -1,5 +1,6 @@
 ---
 target: ipq40xx/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_avm_fritzbox_7530_dsa.yml
+++ b/group_vars/model_avm_fritzbox_7530_dsa.yml
@@ -1,5 +1,4 @@
 ---
-openwrt_version: snapshot
 target: ipq40xx/generic
 override_target: "avm_fritzbox-7530"
 

--- a/group_vars/model_avm_fritzrepeater_3000.yml
+++ b/group_vars/model_avm_fritzrepeater_3000.yml
@@ -1,5 +1,6 @@
 ---
 target: ipq40xx/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_bananapi_bpi_r2.yml
+++ b/group_vars/model_bananapi_bpi_r2.yml
@@ -1,5 +1,6 @@
 ---
 target: mediatek/mt7623
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - wan

--- a/group_vars/model_bananapi_bpi_r64.yml
+++ b/group_vars/model_bananapi_bpi_r64.yml
@@ -1,5 +1,6 @@
 ---
 target: mediatek/mt7622
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - wan

--- a/group_vars/model_glinet_gl_b1300.yml
+++ b/group_vars/model_glinet_gl_b1300.yml
@@ -1,5 +1,6 @@
 ---
 target: ipq40xx/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_linksys_e8450_ubi.yml
+++ b/group_vars/model_linksys_e8450_ubi.yml
@@ -1,5 +1,6 @@
 ---
 target: mediatek/mt7622
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - wan

--- a/group_vars/model_mikrotik_routerboard_750gr3.yml
+++ b/group_vars/model_mikrotik_routerboard_750gr3.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - wan

--- a/group_vars/model_mikrotik_routerboard_760igs.yml
+++ b/group_vars/model_mikrotik_routerboard_760igs.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - sfp

--- a/group_vars/model_mikrotik_routerboard_wap_g_5hact2hnd.yml
+++ b/group_vars/model_mikrotik_routerboard_wap_g_5hact2hnd.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "mikrotik_routerboard-wap-g-5hact2hnd"
 target: ath79/mikrotik
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_mikrotik_sxtsq_2_lite.yml
+++ b/group_vars/model_mikrotik_sxtsq_2_lite.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "mikrotik_routerboard-lhg-2nd"
 target: ath79/mikrotik
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_mikrotik_sxtsq_5_ac.yml
+++ b/group_vars/model_mikrotik_sxtsq_5_ac.yml
@@ -1,5 +1,6 @@
 ---
 target: ipq40xx/mikrotik
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_mikrotik_wap_ac.yml
+++ b/group_vars/model_mikrotik_wap_ac.yml
@@ -1,5 +1,4 @@
 ---
-openwrt_version: snapshot
 target: ipq40xx/mikrotik
 
 model__packages__to_merge:

--- a/group_vars/model_netgear_wax202.yml
+++ b/group_vars/model_netgear_wax202.yml
@@ -1,8 +1,6 @@
 ---
 target: ramips/mt7621
 
-openwrt_version: snapshot
-
 dsa_ports:
   - wan
   - lan1

--- a/group_vars/model_siemens_ws_ap3610.yml
+++ b/group_vars/model_siemens_ws_ap3610.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_tplink_archer_a7_v5.yml
+++ b/group_vars/model_tplink_archer_a7_v5.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_archer_c50_v3.yml
+++ b/group_vars/model_tplink_archer_c50_v3.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt76x8
+openwrt_version: 22.03-SNAPSHOT
 
 switch_ports: 7
 switch_int_port: 6

--- a/group_vars/model_tplink_archer_c5_v1.yml
+++ b/group_vars/model_tplink_archer_c5_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_archer_c6_v2.yml
+++ b/group_vars/model_tplink_archer_c6_v2.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 switch_ports: 7
 switch_int_port: 0

--- a/group_vars/model_tplink_archer_c7_v2.yml
+++ b/group_vars/model_tplink_archer_c7_v2.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_archer_c7_v5.yml
+++ b/group_vars/model_tplink_archer_c7_v5.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_tplink_cpe210_v1.yml
+++ b/group_vars/model_tplink_cpe210_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 # PoE port is eth1, 2nd port is eth0
 # override port in host_vars if required

--- a/group_vars/model_tplink_cpe510_v1.yml
+++ b/group_vars/model_tplink_cpe510_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth1
 

--- a/group_vars/model_tplink_eap225_outdoor_v1.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v1.yml
@@ -1,6 +1,5 @@
 ---
 target: ath79/generic
-openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_tplink_eap225_outdoor_v1.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_tplink_tl_wdr3500_v1.yml
+++ b/group_vars/model_tplink_tl_wdr3500_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 switch_ports: 5
 switch_int_port: 0

--- a/group_vars/model_tplink_tl_wdr3600_v1.yml
+++ b/group_vars/model_tplink_tl_wdr3600_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 switch_ports: 6
 switch_int_port: 0

--- a/group_vars/model_tplink_tl_wdr4300_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4300_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 switch_ports: 6
 switch_int_port: 0

--- a/group_vars/model_tplink_tl_wdr4900_v1.yml
+++ b/group_vars/model_tplink_tl_wdr4900_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: mpc85xx/p1010
+openwrt_version: 22.03-SNAPSHOT
 
 switch_ports: 6
 switch_int_port: 0

--- a/group_vars/model_ubnt_bullet_m_ar7241.yml
+++ b/group_vars/model_ubnt_bullet_m_ar7241.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_bullet-m-ar7241"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_edgerouter_4.yml
+++ b/group_vars/model_ubnt_edgerouter_4.yml
@@ -1,5 +1,6 @@
 ---
 target: octeon/generic
+openwrt_version: 22.03-SNAPSHOT
 
 target__packages__to_merge:
   - naywatch

--- a/group_vars/model_ubnt_edgerouter_x.yml
+++ b/group_vars/model_ubnt_edgerouter_x.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - eth0

--- a/group_vars/model_ubnt_edgerouter_x_sfp.yml
+++ b/group_vars/model_ubnt_edgerouter_x_sfp.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - eth0

--- a/group_vars/model_ubnt_nanobeam_ac_xc.yml
+++ b/group_vars/model_ubnt_nanobeam_ac_xc.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct -kmod-ath10k-ct-smallbuffers"

--- a/group_vars/model_ubnt_nanostation_ac_loco.yml
+++ b/group_vars/model_ubnt_nanostation_ac_loco.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_nanostation_loco_m2_xm.yml
+++ b/group_vars/model_ubnt_nanostation_loco_m2_xm.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_nanostation-loco-m"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_nanostation_loco_m5_xm.yml
+++ b/group_vars/model_ubnt_nanostation_loco_m5_xm.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_nanostation-loco-m"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_nanostation_loco_m5_xw.yml
+++ b/group_vars/model_ubnt_nanostation_loco_m5_xw.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_nanostation-loco-m-xw"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0
 

--- a/group_vars/model_ubnt_nanostation_m2_xm.yml
+++ b/group_vars/model_ubnt_nanostation_m2_xm.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_nanostation-m"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth1
 

--- a/group_vars/model_ubnt_nanostation_m5_xm.yml
+++ b/group_vars/model_ubnt_nanostation_m5_xm.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_nanostation-m"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth1
 

--- a/group_vars/model_ubnt_nanostation_m5_xw.yml
+++ b/group_vars/model_ubnt_nanostation_m5_xw.yml
@@ -1,6 +1,7 @@
 ---
 override_target: "ubnt_nanostation-m-xw"
 target: ath79/tiny
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth1
 

--- a/group_vars/model_ubnt_rocket_5ac_lite.yml
+++ b/group_vars/model_ubnt_rocket_5ac_lite.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_unifi_6_lite.yml
+++ b/group_vars/model_ubnt_unifi_6_lite.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - lan

--- a/group_vars/model_ubnt_unifiac_lite.yml
+++ b/group_vars/model_ubnt_unifiac_lite.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_unifiac_mesh.yml
+++ b/group_vars/model_ubnt_unifiac_mesh.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-tcpdump -tmux -mtr -ethtool -iperf3 -curl -vnstat -kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_unifiac_pro.yml
+++ b/group_vars/model_ubnt_unifiac_pro.yml
@@ -1,5 +1,6 @@
 ---
 target: ath79/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"

--- a/group_vars/model_ubnt_usw_flex.yml
+++ b/group_vars/model_ubnt_usw_flex.yml
@@ -8,7 +8,6 @@
 # - one 14720k partition, vendor two 7360k partitions
 
 target: ramips/mt7621
-openwrt_version: snapshot
 
 dsa_ports:
   - lan1

--- a/group_vars/model_x86_64.yml
+++ b/group_vars/model_x86_64.yml
@@ -2,5 +2,6 @@
 
 target: x86/64
 override_target: generic
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth0

--- a/group_vars/model_xiaomi_mi_router_3g_v2.yml
+++ b/group_vars/model_xiaomi_mi_router_3g_v2.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - eth0

--- a/group_vars/model_zyxel_nbg6617.yml
+++ b/group_vars/model_zyxel_nbg6617.yml
@@ -1,5 +1,6 @@
 ---
 target: ipq40xx/generic
+openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca4019-ct"

--- a/group_vars/model_zyxel_nwa50ax.yml
+++ b/group_vars/model_zyxel_nwa50ax.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 22.03-SNAPSHOT
 
 int_port: lan
 

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -1,8 +1,6 @@
 ---
 target: ramips/mt7621
 
-openwrt_version: snapshot
-
 dsa_ports:
   - lan
 

--- a/group_vars/version_23_05_snapshot.yml
+++ b/group_vars/version_23_05_snapshot.yml
@@ -1,0 +1,2 @@
+---
+feed_version: 1.4.0-snapshot


### PR DESCRIPTION
- Switch default OpenWrt version from 22.03 to 23.05
- Remove explicit version from device models that previously used snapshot
- Add explicit 22.03 version to device models that previously used the default 22.03

This should result in no direct meaningful changes for devices.