### PR TITLE
Makefile: Updated position of linters in folder structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 lint: deps
-	yamllint -d .config/yaml-lint.yml .
-	ansible-lint -c .config/ansible-lint.yml
+	yamllint -d .github/linters/.yaml-lint.yml .
+	ansible-lint -c .github/linters/.ansible-lint.yml
 
 configs: deps lint
 	time ansible-playbook play.yml


### PR DESCRIPTION
Since the linter where moved the makefile wasn't working. Changed the path of the linters to its new folders.