### PR TITLE
Fixed modelnames for kts13-core and cafe-wostock-core

### DIFF
--- a/host_vars/cafe-wostok-core/base.yml
+++ b/host_vars/cafe-wostok-core/base.yml
@@ -2,4 +2,4 @@
 
 location: cafe-wostok
 role: corerouter
-model: "avm_fritzbox-7530_dsa"
+model: "avm_fritzbox-7530"

--- a/host_vars/kts13-core/base.yml
+++ b/host_vars/kts13-core/base.yml
@@ -2,6 +2,6 @@
 
 location: kts13
 role: corerouter
-model: "avm_fritzbox-7530_dsa"
+model: "avm_fritzbox-7530"
 
 wireless_profile: disable


### PR DESCRIPTION
kts13-core and cafe-wostock-core used a model-name with "avm_fritzbox-7530_dsa"", which doesnt exist resulting in an error. Fixed the modelnames by removing "_dsa".