### PR TITLE
templates: fix mss clamping for 23.05

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/nftables.d/20-wg-maxseg-size.nft.j2
+++ b/roles/cfg_openwrt/templates/corerouter/nftables.d/20-wg-maxseg-size.nft.j2
@@ -1,4 +1,4 @@
-{% if (networks | selectattr('tunnel_wan_ip', 'defined') | count > 0) and ((openwrt_version == 'snapshot') or ('22.03' in openwrt_version)) %}
+{% if (networks | selectattr('tunnel_wan_ip', 'defined') | count > 0) %}
 {% set TCP_HEADER_SIZE = 20 %}
 {% set IPV4_HEADER_SIZE = 20 %}
 {% set IPV6_HEADER_SIZE = 40 %}


### PR DESCRIPTION
The switch to firewall4 made it necessary to check if we have 22.03 or snapshot when we create firewall rules. However, we forgot to check for 23.05. Since we abondned 21.02 we can remove the check for firewall4 completely.