### PR TITLE
dhcp: provision of static routes to Freifunk IPs

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -41,6 +41,7 @@ config dhcp 'dhcp_{{ name }}'
 	option leasetime '5m'
 	option start '2'
 	option limit '{{ network['prefix'] | ansible.utils.ipaddr('size') -3 }}'
+        list dhcp_option '121,0.0.0.0/0,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.31.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.36.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.230.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }}'
     {% else %}
 	option dhcpv4 'disabled'
     {% endif %}


### PR DESCRIPTION
This pull request enables the core router to announces routes to our IP networks (10.31.0.0/16, 10.36.0.0/16, 10.230.0.0/16) via DHCP option 121. This enables clients connected to multiple networks to reach Freifunk IPs without manually adding static routes.