### PR TITLE
network: randomize MAC address of mesh interfaces

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -33,9 +33,9 @@ config interface '{{ name }}'
     {% if port_needed %}
 	option device '{{ ('br-' + name) if bridge_needed else port }}'
     {% endif %}
+	option macaddr '22:{{ lookup('password', '/dev/null chars="digits" length=2') | lower }}:{{ lookup('password', '/dev/null chars="digits" length=2') | lower }}:{{ lookup('password', '/dev/null chars="digits" length=2') | lower }}:{{ lookup('password', '/dev/null chars="digits" length=2') | lower }}:{{ lookup('password', '/dev/null chars="digits" length=2') | lower }}'
     {% if network.get('enforce_client_isolation') and role == 'corerouter' and
           not bridge_needed %}
-	option macaddr '02:00:00:00:00:01'
     {% endif %}
     {% if 'assignments' in network and inventory_hostname in network['assignments'] %}
 	option proto 'static'


### PR DESCRIPTION
When radios that bridge all VLANs are used in conjunction with unmanaged switches, a situation can arise where the switch gets confused about which port specific MAC address is available on since all of the core router mesh interfaces use the same MAC address.

For example:
The issue happens for me because i'm using a unmanged dumb switch to supply my antennas.

This dumb switch is really bridging all vlans on all ports. Not nice, but that means that mesh Traffic from my wilgu10-sama antenna is bridged to the AF60-LR towards sama, where it gets dropped, because that VLAN is not configured on that port

on linux you have by default the same mac address on every VLAN interface

When following packet is sent it will break it every time Sama-core VLAN 10 ->
sama-switch ->
sama-sued-5ghz (untag vlan10) ->
wilgu10-sama (tag vlan 12) ->
dumb switch (floods broadcast on all ports) ->
wilgu10-sama-60ghz

The wilgu10-sama-60ghz seems to learn the mac address of sama-core router on the local ethernet interface, leading to packet loss. When the next packet from sama is received via 60G its resolved until next packet via 5Ghz/Ethernet is received