### PR TITLE
models: nanostation m5 xw is not tiny

### DIFF
--- a/group_vars/model_ubnt_nanostation_m5_xw.yml
+++ b/group_vars/model_ubnt_nanostation_m5_xw.yml
@@ -1,6 +1,6 @@
 ---
 override_target: "ubnt_nanostation-m-xw"
-target: ath79/tiny
+target: ath79/generic
 openwrt_version: 22.03-SNAPSHOT
 
 int_port: eth1


### PR DESCRIPTION
The nanostation m5 xw has 8 MB of flash and 64 MB of RAM and is not a tiny device. Without this fix firmware for the device can't be build.