### PR TITLE
bht: modify the dfs timing and metric at bht

### DIFF
--- a/group_vars/location_bht/airos_dfs_reset.yml
+++ b/group_vars/location_bht/airos_dfs_reset.yml
@@ -59,4 +59,4 @@ airos_dfs_reset:
     target: "10.31.166.14"
     username: "root"
     password: "file:/root/pwd.txt"
-    daytime_limit: "2-7"
+    daytime_limit: "0-23"

--- a/group_vars/location_bht/networks.yml
+++ b/group_vars/location_bht/networks.yml
@@ -8,7 +8,7 @@ networks:
     prefix: 10.230.23.141/32
     ipv6_subprefix: -1
     ptp: true
-    mesh_metric: 512
+    mesh_metric: 1024
     mesh_metric_lqm: ['default 0.2']
 
   - vid: 112


### PR DESCRIPTION
Modify the timing for a dfs reset at bht to 0-23 (request from Carsten)

Give the link to Segen a worse metric since the link quality bht-segen is so poor.  This makes the preference for internet access to go over perleberger36->strom-gw.

This image has already been built and is currently runing on bht-core