### PR TITLE
Wikiupdater: Made execution optional

### DIFF
--- a/roles/cfg_openwrt/tasks/main.yml
+++ b/roles/cfg_openwrt/tasks/main.yml
@@ -105,7 +105,9 @@
     file: wikiupdater.yml
     apply:
       tags: wiki
-  tags: wiki
+  tags:
+    - never
+    - wiki
   when: role == "corerouter"
 
 - name: Wikiupdaterinfo
@@ -113,5 +115,7 @@
     msg:
       - Role from your current device is {{ role }}. Wikiupdater needs to be run with the Corerouter.
       - You might need to change your limit to include the core-router if you dont get the desired output.
-  tags: wiki
+  tags:
+    - never
+    - wiki
   when: role != "corerouter"


### PR DESCRIPTION
Added option so that the task is only executed when the wiki tag is given. Before it was executed every time.