### PR TITLE
templates: check 15 character limit for bridges

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -21,6 +21,7 @@ config interface 'loopback'
 {% for network in networks %}
   {% set name = network['name'] if 'name' in network else network['role'] %}
   {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
+  {% set bridge_name = 'br-' + name %}
   {% set bridge_needed = name in wifi_networks or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and 'tunnel_wan_ip' in network) %}
   {% set port_needed = not (role == 'corerouter' and network.get('mesh_ap') == inventory_hostname) %}
 
@@ -31,7 +32,11 @@ config interface 'loopback'
      %}
 config interface '{{ name }}'
     {% if port_needed %}
-	option device '{{ ('br-' + name) if bridge_needed else port }}'
+        {% if bridge_needed %}
+        option device '{{ (bridge_name if bridge_name | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
+        {% else %}
+        option device '{{ port }}'
+        {% endif %}
     {% endif %}
     {% if network.get('enforce_client_isolation') and role == 'corerouter' and
           not bridge_needed %}
@@ -70,7 +75,7 @@ config interface '{{ name }}'
 
   {% if port_needed and bridge_needed %}
 config device
-	option name 'br-{{ name }}'
+	option name '{{ (bridge_name if bridge_name | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
         option type 'bridge'
     {% if network.get('enforce_client_isolation') and role == 'corerouter' %}
 	option macaddr '02:00:00:00:00:01'

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -119,7 +119,7 @@ config wifi-iface '{{ wd_id }}_if{{ loop.index0 }}'
       {% if 'mcast_rate' in iface %}
 	option mcast_rate '{{ iface['mcast_rate'] }}'
       {% endif %}
-	option network '{{ (mesh_net['name'] if mesh_net['name'] | length < 15) | mandatory('Network name is longer than 15 characters') }}'
+	option network '{{ (mesh_net['name'] if mesh_net['name'] | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
     {% endif %}
     {% endif %}
   {% endfor %}

--- a/roles/cfg_openwrt/templates/corerouter/config/tunnelmanager.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunnelmanager.j2
@@ -1,8 +1,9 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 {% for network in networks | selectattr('tunnel_wan_ip', 'defined') %}
   {% set name = network['name'] if 'name' in network else network['role'] %}
+  {% set bridge_name = 'br-' + name %}
 config tunnelmanager '{{ name }}'
-	option interface 'br-{{ name }}'
+	option interface '{{ (bridge_name if bridge_name | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
 	option namespace '{{ network['tunnel_namespace']|default(name) }}'
 	option mtu '{{ network['tunnel_mtu']|default(1412) }}'
 	option uplink_ip '{{ network['tunnel_wan_ip'] }}'


### PR DESCRIPTION
This commit adds the 15 character limit check for bridge interfaces and adjusts the condition to actually check for 15 characters.  This resolves #185. The 15 character limit is mentioned here: https://openwrt.org/docs/guide-user/network/tunneling_interface_protocols

