### PR TITLE
models: use snapshot for mt7915 and do not use DSA for devices with one port

### DIFF
--- a/group_vars/model_dlink_dap_x1860_a1.yml
+++ b/group_vars/model_dlink_dap_x1860_a1.yml
@@ -1,8 +1,8 @@
 ---
 target: ramips/mt7621
+openwrt_version: snapshot
 
-dsa_ports:
-  - lan
+int_port: lan
 
 wireless_devices:
   - name: 11a_standard

--- a/group_vars/model_netgear_wax202.yml
+++ b/group_vars/model_netgear_wax202.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: snapshot
 
 dsa_ports:
   - wan

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -1,8 +1,8 @@
 ---
 target: ramips/mt7621
+openwrt_version: snapshot
 
-dsa_ports:
-  - lan
+int_port: lan
 
 wireless_devices:
   - name: 11a_standard


### PR DESCRIPTION
Mesh and rate issues are fixed for mt7915 based devices on snapshot. This commit switches over the devices. In addition we do not use DSA anymore for devices with only one port.