### PR TITLE
github: disable linting rules about comments

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -7,10 +7,6 @@ ignore: |
   venv
 
 rules:
-  comments:
-    level: error
-  comments-indentation:
-    level: error
   document-start:
     level: error
   line-length:


### PR DESCRIPTION
These two linters make sense for functional comments, e.g. when API documentation is generated from comments and a certain format and syntax needs to be enforced.

Our comments are purely for conveying free-form information to humans. We don't have a need for any specific formatting of comments.

The false-positive rate of the comment rules is obviously very high and leads to frustration that can be avoided at no cost. It's also not good practice to regularly ignore linter errors.

The latest example is #529

The best way forward is to not lint comments.