### PR TITLE
dhcp: add static routes to additional Freifunk IPs

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -41,7 +41,7 @@ config dhcp 'dhcp_{{ name }}'
 	option leasetime '5m'
 	option start '2'
 	option limit '{{ network['prefix'] | ansible.utils.ipaddr('size') -3 }}'
-        list dhcp_option '121,0.0.0.0/0,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.31.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.36.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.230.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }}'
+        list dhcp_option '121,0.0.0.0/0,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.31.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.36.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.230.0.0/16,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }},10.248.0.0/14,{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) | ansible.utils.ipaddr('address') }}'
     {% else %}
 	option dhcpv4 'disabled'
     {% endif %}


### PR DESCRIPTION
Add missing IPs (https://github.com/freifunk/icvpn-meta/commit/a5142788871802bd583f08d040957cb9ced9162e)