### PR TITLE
parzelle17: init location

### DIFF
--- a/locations/parzelle17-fritz.yml
+++ b/locations/parzelle17-fritz.yml
@@ -1,0 +1,80 @@
+---
+location: parzelle17
+location_nice: Parzelle 17
+latitude: 52.478675
+longitude: 13.471268
+community: true
+
+dns_servers:
+  # quad9
+  - 9.9.9.9
+  - 149.112.112.112
+  - 2620:fe::fe
+  - 2620:fe::9
+  # cloudflare
+  - 1.1.1.1
+  - 1.0.0.1
+  - 2606:4700:4700::1111
+  - 2606:4700:4700::1001
+
+hosts:
+  - hostname: parzelle17-fritz-core
+    role: corerouter
+    model: "avm_fritzbox-7530"
+    wireless_profile: freifunk_default
+    openwrt_version: snapshot
+
+ipv6_prefix: '2001:bf7:840:1000::/56'
+
+# config restored from router configuration
+# got following prefixes:
+# Router: 10.31.207.64/26
+# --MGMT: 10.31.207.80/28
+# --MESH: 10.31.207.64/28
+# --DHCP: 10.31.207.96/27
+
+# Disable noping
+dhcp_no_ping: false
+
+networks:
+  # DHCP with filtering and isolation
+  - vid: 40
+    role: dhcp
+    untagged: true
+    inbound_filtering: true
+    enforce_client_isolation: true
+    prefix: 10.31.207.96/27
+    ipv6_subprefix: 0
+    assignments:
+      parzelle17-fritz-core: 1
+
+  # MESH - 5 GHz 802.11s
+  - vid: 20
+    role: mesh
+    name: mesh_5g
+    prefix: 10.31.207.64/32
+    ipv6_subprefix: -20
+    mesh_ap: parzelle17-fritz-core
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  # MESH - 2.4 GHz 802.11s
+  - vid: 21
+    role: mesh
+    name: mesh_2g
+    prefix: 10.31.207.65/32
+    ipv6_subprefix: -21
+    mesh_ap: parzelle17-fritz-core
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  # MGMT
+  - vid: 42
+    role: mgmt
+    prefix: 10.31.207.80/28
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 1
+    assignments:
+      # 10.31.207.81/32
+      parzelle17-fritz-core: 1

--- a/locations/parzelle17.yml
+++ b/locations/parzelle17.yml
@@ -1,0 +1,79 @@
+---
+location: parzelle17
+location_nice: Parzelle 17
+latitude: 52.478675
+longitude: 13.471268
+community: true
+
+dns_servers:
+  # quad9
+  - 9.9.9.9
+  - 149.112.112.112
+  - 2620:fe::fe
+  - 2620:fe::9
+  # cloudflare
+  - 1.1.1.1
+  - 1.0.0.1
+  - 2606:4700:4700::1111
+  - 2606:4700:4700::1001
+
+hosts:
+  - hostname: parzelle17-core
+    role: corerouter
+    model: "dlink_dap-x1860-a1"
+    wireless_profile: freifunk_default
+
+ipv6_prefix: '2001:bf7:840:f00::/56'
+
+# config restored from router configuration
+# got following prefixes:
+# Router: 10.31.207.0/26
+# --MGMT: 10.31.207.0/28
+# --MESH: 10.31.207.16/28
+# --DHCP: 10.31.207.32/27
+
+# Disable noping
+dhcp_no_ping: false
+
+networks:
+  # DHCP with filtering and isolation
+  - vid: 40
+    role: dhcp
+    untagged: true
+    inbound_filtering: true
+    enforce_client_isolation: true
+    prefix: 10.31.207.32/27
+    ipv6_subprefix: 0
+    assignments:
+      parzelle17-core: 1
+
+  # MESH - 5 GHz 802.11s
+  - vid: 20
+    role: mesh
+    name: mesh_5g
+    prefix: 10.31.207.16/32
+    ipv6_subprefix: -20
+    mesh_ap: parzelle17-core
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  # MESH - 2.4 GHz 802.11s
+  - vid: 21
+    role: mesh
+    name: mesh_2g
+    prefix: 10.31.207.17/32
+    ipv6_subprefix: -21
+    mesh_ap: parzelle17-core
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  # MGMT
+  - vid: 42
+    role: mgmt
+    prefix: 10.31.207.0/28
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 1
+    assignments:
+      # 10.31.207.1/32
+      parzelle17-core: 1


### PR DESCRIPTION
This commit bringt the new location parzelle17, which is used for testing MT7915 meshing in a crowdy environment.