### PR TITLE
model: switch mt7915 devices to 23.05

### DIFF
--- a/group_vars/model_dlink_dap_x1860_a1.yml
+++ b/group_vars/model_dlink_dap_x1860_a1.yml
@@ -1,6 +1,5 @@
 ---
 target: ramips/mt7621
-openwrt_version: snapshot
 
 int_port: lan
 

--- a/group_vars/model_netgear_wax202.yml
+++ b/group_vars/model_netgear_wax202.yml
@@ -1,6 +1,5 @@
 ---
 target: ramips/mt7621
-openwrt_version: snapshot
 
 dsa_ports:
   - wan

--- a/group_vars/model_zyxel_nwa50ax.yml
+++ b/group_vars/model_zyxel_nwa50ax.yml
@@ -1,6 +1,5 @@
 ---
 target: ramips/mt7621
-openwrt_version: 22.03-SNAPSHOT
 
 int_port: lan
 

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -1,6 +1,5 @@
 ---
 target: ramips/mt7621
-openwrt_version: snapshot
 
 int_port: lan
 


### PR DESCRIPTION
Mesh is stable now in 23.05 with the latest fixes, therefore switch the devices over to 23.05