### PR TITLE
networks: add tunnel role for use with tunspace

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -155,28 +155,29 @@ The VLAN ID (vid) usually follow this numbering convention.
 ##### uplink via tunnel
 
 If for some reason you are in need of an uplink via a "normal" internet connection, a wireguard
-tunnel can be an easy and safe solution. In that case add another vlan to the networks.yml
+tunnel can be an easy and safe solution. In that case you can add one or more tunnel networks:
 
 ```yml
-  - vid: 50
-    untagged: true            # option to don't tag this vlan - useful if the corerouter is plugged into a normal home router
-    name: uplink
-    role: uplink
-    tunnel_wan_ip: 192.168.1.2/24   # put here the address and subnet of the corerouter inside the uplink network
-    tunnel_wan_gw: 192.168.1.1      # gateway of the uplink network
-    tunnel_connections: 2           # default value, number of different tunnels to create
-    tunnel_timeout: 600             # timeout in seconds after this the tunnel is destroyed and attempted to be rebuild
-    tunnel_mesh_prefix_ipv4: 10.31.142.120/30   # ip subnet to pick addresses for the endpoints of the tunnels
-    tunnel_up_script_args: '10.31.142.120/30 12800 0.4'    # Mesh Prefix, Babel Metric, OLSR LQM (optional, these values are the default)
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.142.120/32
+    wireguard_port: 51820
+
+  - role: tunnel
+    ifname: ts_wg1
+    mtu: 1280
+    prefix: 10.31.142.121/32
+    wireguard_port: 51821
 ```
 
-The values of the Babel Metric and the OLSR LQM influence how the uplink works. If the uplink tunnel is intended
+The values of the Babel Metric and the OLSR LQM are optional and influence how the uplink works. If the uplink tunnel is intended
 as a backup connection, and you see traffic flow through the tunnel, you should set a higher value for the babeld
 metric and a lower value for the OLSR LQM. The lowest possible LQM value is 0.2. Below that value the uplink will
 not work.
 
 If there are routes via the tunnels the following command will show a non empty result, when run on the node
-`(echo /routes | nc 127.0.0.1 9090) | grep '"networkInterface": "wg_'`. In this case you should adjust the link metrics
+`(echo /routes | nc 127.0.0.1 9090) | grep '"networkInterface": "ts_'`. In this case you should adjust the link metrics
 for uplinks that should only act as backup connection.
 
 If you have multiple uplinks and want one to be prefered, set different link metrics for the different uplinks.

--- a/group_vars/location_cafe_wostok/networks.yml
+++ b/group_vars/location_cafe_wostok/networks.yml
@@ -29,13 +29,13 @@ networks:
 
   - vid: 50
     untagged: true
-    name: easybell
     role: uplink
-    tunnel_wan_ip: 192.168.0.10/24
-    tunnel_wan_gw: 192.168.0.1
-    tunnel_connections: 1
-    tunnel_timeout: 600
-    tunnel_mesh_prefix_ipv4: 10.31.161.156/30
+
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.161.152/32
+    wireguard_port: 51820
 
 
 location__channel_assignments_11a_standard__to_merge:

--- a/group_vars/location_kts13/networks.yml
+++ b/group_vars/location_kts13/networks.yml
@@ -42,14 +42,14 @@ networks:
       kts13-ap1: 2
 
   - vid: 50
-    role: uplink
-    name: otwo
     untagged: true
-    tunnel_wan_ip: '192.168.254.2/24'
-    tunnel_wan_gw: '192.168.254.1'
-    tunnel_connections: 1
-    tunnel_timeout: 600
-    tunnel_mesh_prefix_ipv4: '10.31.166.192/28'
+    role: uplink
+
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.166.195/32
+    wireguard_port: 51820
 
 location__channel_assignments_11a_standard__to_merge:
   kts13-ap1: 36-40-7                                   # 7 dBm + 16 dBi gain = 23 dBm

--- a/group_vars/location_rotelilly/networks.yml
+++ b/group_vars/location_rotelilly/networks.yml
@@ -48,13 +48,12 @@ networks:
   - vid: 50
     untagged: true
     role: uplink
-    name: easybell
-    tunnel_wan_ip: 192.168.1.4/24
-    tunnel_wan_gw: 192.168.1.1
-    tunnel_connections: 1
-    tunnel_timeout: 600
-    tunnel_mtu: 1400
-    tunnel_mesh_prefix_ipv4: 10.31.198.17/32
+
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.198.17/32
+    wireguard_port: 51820
 
 location__channel_assignments_11a_standard__to_merge:
   rotelilly-core: 44-40-8

--- a/host_vars/cafe-wostok-core/base.yml
+++ b/host_vars/cafe-wostok-core/base.yml
@@ -3,3 +3,8 @@
 location: cafe-wostok
 role: corerouter
 model: "avm_fritzbox-7530"
+
+host__packages__to_merge:
+  - -tunnelmanager
+  - tunspace
+  - wireguard-tools

--- a/host_vars/kts13-core/base.yml
+++ b/host_vars/kts13-core/base.yml
@@ -5,3 +5,8 @@ role: corerouter
 model: "avm_fritzbox-7530"
 
 wireless_profile: disable
+
+host__packages__to_merge:
+  - -tunnelmanager
+  - tunspace
+  - wireguard-tools

--- a/host_vars/rotelilly-core/base.yml
+++ b/host_vars/rotelilly-core/base.yml
@@ -5,3 +5,8 @@ role: corerouter
 model: "mikrotik_wap-ac"
 
 wireless_profile: freifunk_default
+
+host__packages__to_merge:
+  - -tunnelmanager
+  - tunspace
+  - wireguard-tools

--- a/roles/cfg_openwrt/templates/common/config/dsa.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/dsa.network.inc
@@ -2,7 +2,7 @@ config device
 	option type 'bridge'
 	option name 'switch0'
 
-{% for network in networks %}
+{% for network in networks | selectattr('vid', 'defined') %}
   {% set portmapping = [] %}
   {% for port in dsa_ports %}
     {% set tagged = not network.get('untagged') %}

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -18,17 +18,18 @@ config interface 'loopback'
 {% endif %}
 
 
-{% for network in networks %}
+{% for network in networks | selectattr('vid', 'defined') %}
   {% set name = network['name'] if 'name' in network else network['role'] %}
   {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
   {% set bridge_name = 'br-' + name %}
-  {% set bridge_needed = name in wifi_networks or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and 'tunnel_wan_ip' in network) %}
+  {% set bridge_needed = name in wifi_networks or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and 'tunnel_wan_ip' in network) or (role == 'corerouter' and network['role'] == 'uplink') %}
   {% set port_needed = not (role == 'corerouter' and network.get('mesh_ap') == inventory_hostname) %}
 
   {%- if (role == 'corerouter' and network['role'] == 'mesh') or ('assignments' in network and inventory_hostname in network['assignments'])
      or name in wifi_networks
      or network.get('mesh_ap') == inventory_hostname
      or (role == 'corerouter' and 'tunnel_wan_ip' in network)
+     or (role == 'corerouter' and network['role'] == 'uplink')
      %}
 config interface '{{ name }}'
     {% if port_needed %}
@@ -48,7 +49,7 @@ config interface '{{ name }}'
 	{% if role != "corerouter" and 'dns' in network %}
 	option dns '{{ network['prefix'] | ansible.utils.ipaddr(network['dns']) | ansible.utils.ipaddr('address') }}'
         {% endif %}
-	{% if 'gateway' in network and network['assignments'][inventory_hostname] != network['gateway'] %}
+	{% if 'gateway' in network and 'assignments' in network and network['assignments'][inventory_hostname] != network['gateway'] %}
 	option gateway '{{ network['prefix'] | ansible.utils.ipaddr(network['gateway']) | ansible.utils.ipaddr('address') }}'
         {% endif %}
         {% if role != 'corerouter' and 'ipv6_subprefix' in network %}

--- a/roles/cfg_openwrt/templates/common/config/swconfig.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/swconfig.network.inc
@@ -6,7 +6,7 @@ config switch
 {% else %}
 	option enable_vlan '1'
 
-  {% for network in networks %}
+  {% for network in networks | selectattr('vid', 'defined') %}
     {% set portmapping = [] %}
     {% for port in range(switch_ports)|list|difference(switch_ignore_ports|default([])) %}
       {% set tagged = not network.get('untagged') or port == switch_int_port %}

--- a/roles/cfg_openwrt/templates/common/sysctl.conf.j2
+++ b/roles/cfg_openwrt/templates/common/sysctl.conf.j2
@@ -9,7 +9,7 @@ vm.swappiness=100
 {% endif %}
 
 {% if role == 'ap' %}
-  {% for network in networks %}
+  {% for network in networks | selectattr('vid', 'defined') %}
   {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
   {% if 'ipv6_subprefix' in network and 'assignments' in network and inventory_hostname in network['assignments'] %}
 net.ipv6.conf.{{ port | replace('.', '/') }}.accept_ra=2

--- a/roles/cfg_openwrt/templates/corerouter/config/babeld.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/babeld.j2
@@ -22,6 +22,20 @@ config filter
 
   {% endfor -%}
 
+  {% for tunnel in networks | selectattr('role', 'equalto', 'tunnel') %}
+config interface
+	option 'ifname' '{{ tunnel['ifname'] }}'
+	option 'split_horizon' 'true'
+
+config filter
+	option 'type' 'in'
+	option 'if' '{{ tunnel['ifname'] }}'
+	option 'ip' '::/0'
+	option 'eq' '0'
+	option 'action' 'metric {{ tunnel['mesh_metric']|default(512) }}'
+
+  {% endfor %}
+
 config filter
 	option 'type'	'redistribute'
 	option 'ip'	'{{ ipv6_prefix }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -27,7 +27,7 @@ config domain '{{ host | replace('-', '_') }}_olsr'
   {% endfor %}
 {% endfor %}
 
-{% for network in networks | rejectattr('role', 'in', ['uplink', 'mesh']) %}
+{% for network in networks | rejectattr('role', 'in', ['uplink', 'mesh', 'tunnel']) %}
     {% set name = network['name'] if 'name' in network else network['role'] %}
 
 config dhcp 'dhcp_{{ name }}'
@@ -54,7 +54,7 @@ config domain 'frei_funk_{{ name }}'
     {% endif %}
 {% endfor %}
 
-{% for network in networks | selectattr('role','in', ['uplink', 'mesh']) %}
+{% for network in networks | selectattr('role','in', ['uplink', 'mesh', 'tunnel']) %}
     {% set name = network['name'] if 'name' in network else network['role'] %}
 config dhcp 'dhcp_{{ name }}'
 	option interface '{{ name }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/firewall.j2
@@ -21,6 +21,7 @@ config zone 'zone_freifunk'
 	list network '{{ name }}'
 	{% endfor %}
 	list device 'wg_+'
+	list device 'ts_+'
 
 {% for i in l3_networks | selectattr('inbound_filtering') %}
 config zone 'zone_{{ i['name'] }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
@@ -71,3 +71,14 @@ config Hna4
 	option netaddr '{{ network['prefix'] | ansible.utils.ipaddr('network') }}'
   {% endif %}
 {% endfor %}
+
+{% for tunnel in networks | selectattr('role', 'equalto', 'tunnel') %}
+config Interface
+	option interface '{{ tunnel['ifname'] }}'
+	option Mode 'ether'
+		{% for lqm in tunnel['mesh_metric_lqm']|default([]) %}
+	list LinkQualityMult '{{ lqm }}'
+		{% endfor %}
+	option ignore 0
+
+{% endfor %}

--- a/roles/cfg_openwrt/templates/corerouter/config/tunnelmanager.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunnelmanager.j2
@@ -5,7 +5,7 @@
 config tunnelmanager '{{ name }}'
 	option interface '{{ (bridge_name if bridge_name | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
 	option namespace '{{ network['tunnel_namespace']|default(name) }}'
-	option mtu '{{ network['tunnel_mtu']|default(1412) }}'
+	option mtu '{{ network['tunnel_mtu']|default(1280) }}'
 	option uplink_ip '{{ network['tunnel_wan_ip'] }}'
 	option uplink_gateway '{{ network['tunnel_wan_gw'] }}'
 	option tunnel_count '{{ network['tunnel_connections']|default(2) }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
@@ -1,0 +1,31 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+{% for uplink in networks | selectattr('role', 'equalto', 'uplink') %}
+  {% set name = uplink['name'] if 'name' in uplink else 'uplink' %}
+
+config tunspace "tunspace"
+  option uplink_netns "{{ name }}"
+  option uplink_ifname "br-{{ name }}"
+  option maintenance_interval 60
+  option debug 1
+{% endfor %}
+
+{% for tunnel in networks | selectattr('role', 'equalto', 'tunnel') %}
+config wg-interface
+  option ifname "{{ tunnel['ifname'] }}"
+  option ipv6 "fe80::2/64"
+  option ipv4 "{{ tunnel['prefix'] }}"
+  option mtu {{ tunnel['mtu'] }}
+  option port {{ tunnel['wireguard_port'] }}
+  option keyfile "/etc/tunspace/{{ tunnel['ifname'] }}.key"
+  option disabled 0
+
+{% endfor %}
+
+{% for gateway in groups['role_gateway'] %}
+config wg-server
+  option name "{{ gateway }}"
+  option url "https://{{ hostvars[gateway]['uplink']['ipv4'] | ansible.utils.ipaddr('address') }}/ubus"
+  option check_cert 0
+  option disabled 0
+
+{% endfor %}

--- a/roles/cfg_openwrt/templates/corerouter/firewall.user.j2
+++ b/roles/cfg_openwrt/templates/corerouter/firewall.user.j2
@@ -1,4 +1,4 @@
-{% if (networks | selectattr('tunnel_wan_ip', 'defined') | count > 0) and (openwrt_version != 'snapshot') %}
+{% if (networks | selectattr('tunnel_wan_ip', 'defined') | count > 0) and openwrt_version.startswith('22.') %}
 ip6tables -A forwarding_rule -o wg_+ -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1352
 ip6tables -A forwarding_rule -i wg_+ -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1352
 iptables -A forwarding_rule -o wg_+ -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1372

--- a/roles/cfg_openwrt/templates/corerouter/nftables.d/20-wg-maxseg-size.nft.j2
+++ b/roles/cfg_openwrt/templates/corerouter/nftables.d/20-wg-maxseg-size.nft.j2
@@ -11,3 +11,17 @@ chain wg_maxseg {
 	iifname "wg_*" tcp flags syn tcp option maxseg size set meta nfproto map { ipv4 : {{ ipv4_mss }}, ipv6 : {{ ipv6_mss }} }
 }
 {% endif %}
+
+{% if (networks | selectattr('role', 'equalto', 'tunnel') | count > 0) %}
+{% set TCP_HEADER_SIZE = 20 %}
+{% set IPV4_HEADER_SIZE = 20 %}
+{% set IPV6_HEADER_SIZE = 40 %}
+{% set min_mtu = ([1280] + (networks | selectattr('role', 'equalto', 'tunnel') | map(attribute='mtu') | list)) | min | int %}
+{% set ipv4_mss = min_mtu - TCP_HEADER_SIZE - IPV4_HEADER_SIZE %}
+{% set ipv6_mss = min_mtu - TCP_HEADER_SIZE - IPV6_HEADER_SIZE %}
+chain wg_maxseg {
+    type filter hook forward priority -1; policy accept;
+	oifname "ts_*" tcp flags syn tcp option maxseg size set meta nfproto map { ipv4 : {{ ipv4_mss }}, ipv6 : {{ ipv6_mss }} }
+	iifname "ts_*" tcp flags syn tcp option maxseg size set meta nfproto map { ipv4 : {{ ipv4_mss }}, ipv6 : {{ ipv6_mss }} }
+}
+{% endif %}

--- a/roles/cfg_openwrt/templates/corerouter/nftables.d/20-wg-maxseg-size.nft.j2
+++ b/roles/cfg_openwrt/templates/corerouter/nftables.d/20-wg-maxseg-size.nft.j2
@@ -2,7 +2,7 @@
 {% set TCP_HEADER_SIZE = 20 %}
 {% set IPV4_HEADER_SIZE = 20 %}
 {% set IPV6_HEADER_SIZE = 40 %}
-{% set min_mtu = ([1412] + (networks | selectattr('tunnel_mtu', 'defined') | map(attribute='tunnel_mtu') | list)) | min | int %}
+{% set min_mtu = ([1280] + (networks | selectattr('tunnel_mtu', 'defined') | map(attribute='tunnel_mtu') | list)) | min | int %}
 {% set ipv4_mss = min_mtu - TCP_HEADER_SIZE - IPV4_HEADER_SIZE %}
 {% set ipv6_mss = min_mtu - TCP_HEADER_SIZE - IPV6_HEADER_SIZE %}
 chain wg_maxseg {


### PR DESCRIPTION
TunSpace is a new attempt at a client for wireguard tunnels - see freifunk-berlin/falter-packages#413 for the source code of TunSpace itself. The server side is still the same setup using wg-installer.

The preliminary syntax for this is:
```yml
role: corerouter
openwrt_version: 23.05-SNAPSHOT  # or snapshot
host__packages__to_merge:
  - -tunnelmanager
  - tunspace
  - wireguard-tools

networks:
  # ... other stuff first ...
  
  - vid: 50
    role: uplink

  - role: tunnel
    ifname: ts_wg0
    mtu: 1412
    prefix: 10.31.123.42/32  # ipv6 prefix is always fe80::2/64
    wireguard_port: 51820
    mesh_metric_lqm:  # optional
      - 'default 0.5'
    mesh_metric: 256  # optional

  - role: tunnel
    ifname: ts_wg1
    # ...
```

Please try it out, for me it has been working well for the past few days. Note that it currently logs to syslog *a lot* - this is intended, we'll make it quieter soon when we're confident it works. Until then you can set `option debug 0` in /etc/config/tunspace.