### PR TITLE
fixup: imagebuilder: temporary fix for a few days

### DIFF
--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -106,6 +106,8 @@
   patch:
     src: "0001-image-fix-image-generation-within-ImageBuilder.patch"
     dest: "{{ imagebuild_dir }}/include/image.mk"
+  when:
+    - 'openwrt_version == "snapshot" or openwrt_version.startswith("23.")'
 
 - name: Run Imagebuilder
   changed_when: false


### PR DESCRIPTION
Make sure we apply that patch only for snapshot and 23.05