### PR TITLE
jup: adjusted metrics of bad bht link

### DIFF
--- a/group_vars/location_jup/networks.yml
+++ b/group_vars/location_jup/networks.yml
@@ -13,6 +13,8 @@ networks:
     name: mesh_bht
     prefix: 10.31.147.128/32
     ipv6_subprefix: -1
+    mesh_metric: 1024
+    mesh_metric_lqm: ['default 0.5']
     ptp: true
 
   - vid: 11


### PR DESCRIPTION
Routing between segen and bht often went via jup. This adjustment fixes this.