### PR TITLE
rio: adjust routing towards emma

### DIFF
--- a/group_vars/location_rio/networks.yml
+++ b/group_vars/location_rio/networks.yml
@@ -13,12 +13,16 @@ networks:
     name: mesh_emma
     prefix: 10.31.134.16/32
     ipv6_subprefix: -1
+    mesh_metric: 2024
+    mesh_metric_lqm: ['default 0.25']
+    ptp: true
 
   - vid: 11
     role: mesh
     name: mesh_simeon
     prefix: 10.31.134.17/32
     ipv6_subprefix: -2
+    ptp: true
 
   - vid: 20
     role: mesh


### PR DESCRIPTION
the link towards emma is poor, therefore adjust mesh metrics so traffic from simeon flows via rhxb, rhnk towards emma