### PR TITLE
network: support untagged VLANs on devices without a switch

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -20,7 +20,11 @@ config interface 'loopback'
 
 {% for network in networks | selectattr('vid', 'defined') %}
   {% set name = network['name'] if 'name' in network else network['role'] %}
-  {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
+  {% if (dsa_ports is defined) or (switch_ports|default(0) > 0) %}
+    {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
+  {% else %}
+    {% set port = ((int_port) + '.' + network['vid']|string if not network.get('untagged') else (int_port)) %}
+  {% endif %}
   {% set bridge_name = 'br-' + name %}
   {% set bridge_needed = name in wifi_networks or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and 'tunnel_wan_ip' in network) or (role == 'corerouter' and network['role'] == 'uplink') %}
   {% set port_needed = not (role == 'corerouter' and network.get('mesh_ap') == inventory_hostname) %}


### PR DESCRIPTION
This fixes #598 and enables untagged VLANs on devices without a switch, e.g. DAP-X1860 so the network port can be used to connect to an untagged network in an uplink configuration or to untag the DHCP network.