### PR TITLE
fffw-lebenshilfe: fix missing package change

### DIFF
--- a/host_vars/fffw-lebenshilfe-core/base.yml
+++ b/host_vars/fffw-lebenshilfe-core/base.yml
@@ -4,4 +4,8 @@ role: corerouter
 model: "avm_fritzbox-7530"
 
 wireless_profile: freifunk_fw
-...
+
+host__packages__to_merge:
+  - -tunnelmanager
+  - tunspace
+  - wireguard-tools


### PR DESCRIPTION
as @PolynomialDivision pointed out the package switch to tunspace was missing. This PR fixes this.