### PR TITLE
treewide: replace tunnelmanager with tunspace

### DIFF
--- a/host_vars/b0russia-core/base.yml
+++ b/host_vars/b0russia-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "linksys_e8450-ubi"
 
 wireless_profile: mesh_only
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/borussia-core/base.yml
+++ b/host_vars/borussia-core/base.yml
@@ -4,9 +4,4 @@ location: borussia
 role: corerouter
 model: "linksys_e8450-ubi"
 
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools
-
 wireless_profile: mesh_only

--- a/host_vars/casa-kua-core/base.yml
+++ b/host_vars/casa-kua-core/base.yml
@@ -2,8 +2,3 @@
 location: casa_kua
 role: corerouter
 model: "glinet_gl-b1300"
-
-host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools

--- a/host_vars/fffw-lebenshilfe-core/base.yml
+++ b/host_vars/fffw-lebenshilfe-core/base.yml
@@ -4,8 +4,3 @@ role: corerouter
 model: "avm_fritzbox-7530"
 
 wireless_profile: freifunk_fw
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/forcki-core/base.yml
+++ b/host_vars/forcki-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "avm_fritzbox-7530"
 
 wireless_profile: freifunk_default
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/habersaath-core/base.yml
+++ b/host_vars/habersaath-core/base.yml
@@ -3,8 +3,3 @@
 location: habersaath
 role: corerouter
 model: "linksys_e8450-ubi"
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/linie206-core/base.yml
+++ b/host_vars/linie206-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "linksys_e8450-ubi"
 
 wireless_profile: freifunk_default
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/linksfraktiontk-core/base.yml
+++ b/host_vars/linksfraktiontk-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "avm_fritzbox-4040"
 
 wireless_profile: freifunk_default
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/mahalle-core/base.yml
+++ b/host_vars/mahalle-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "avm_fritzbox-4040"
 
 wireless_profile: freifunk_default
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/newyorck-core/base.yml
+++ b/host_vars/newyorck-core/base.yml
@@ -2,8 +2,3 @@
 location: newyorck
 role: corerouter
 model: "linksys_e8450-ubi"
-
-host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools

--- a/host_vars/sonnenblume-core/base.yml
+++ b/host_vars/sonnenblume-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "avm_fritzbox-7530"
 
 wireless_profile: freifunk_default
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/host_vars/wuhli-core/base.yml
+++ b/host_vars/wuhli-core/base.yml
@@ -5,8 +5,3 @@ role: corerouter
 model: "tplink_tl-wdr4900-v1"
 
 wireless_profile: freifunk_default
-
-host__packages__to_merge:
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools

--- a/locations/cafe-wostok.yml
+++ b/locations/cafe-wostok.yml
@@ -11,10 +11,6 @@ hosts:
   - hostname: cafe-wostok-core
     role: corerouter
     model: "avm_fritzbox-7530"
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
   - hostname: cafe-wostok-ap1
     role: ap

--- a/locations/elsekiehl.yml
+++ b/locations/elsekiehl.yml
@@ -29,10 +29,6 @@ hosts:
     role: corerouter
     model: "avm_fritzbox-7530"
     wireless_profile: freifunk_default
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
 ipv6_prefix: '2001:bf7:820:1800::/56'
 

--- a/locations/huette15.yml
+++ b/locations/huette15.yml
@@ -31,10 +31,6 @@ hosts:
     role: corerouter
     model: "x86-64"
     wireless_profile: disable
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
 networks:
 

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -27,10 +27,6 @@ hosts:
     role: corerouter
     model: avm_fritzbox-4040
     wireless_profile: disable
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
   - hostname: kirchhof-nf-vorne
     role: ap

--- a/locations/kts13.yml
+++ b/locations/kts13.yml
@@ -17,10 +17,6 @@ hosts:
     role: corerouter
     model: "avm_fritzbox-7530"
     wireless_profile: disable
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
   - hostname: kts13-ap1
     role: ap

--- a/locations/l5.yml
+++ b/locations/l5.yml
@@ -13,10 +13,6 @@ hosts:
     role: corerouter
     model: "avm_fritzbox-4040"
     wireless_profile: freifunk_default
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
   - hostname: l5-nf-o
     role: ap

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -28,10 +28,6 @@ hosts:
     role: corerouter
     model: avm_fritzbox-4040
     wireless_profile: muggel
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
 networks:
 

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -25,10 +25,6 @@ hosts:
     role: corerouter
     model: "dlink_dap-x1860-a1"
     wireless_profile: freifunk_default
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
 ipv6_prefix: '2001:bf7:830:1000::/56'
 

--- a/locations/pktpls.yml
+++ b/locations/pktpls.yml
@@ -18,9 +18,6 @@ hosts:
 location__packages__to_merge:
   - -luci-mod-falter
   - -falter-common
-  - -tunnelmanager
-  - tunspace
-  - wireguard-tools
   - openssh-sftp-server
 
 # 10.31.174.128/26 - pktpls+bbb@systemli.org

--- a/locations/rotelilly.yml
+++ b/locations/rotelilly.yml
@@ -18,10 +18,6 @@ hosts:
     role: corerouter
     model: "mikrotik_wap-ac"
     wireless_profile: freifunk_default
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
 # 10.31.198.0/25
 # 10.31.198.0/28 - mgmt

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -18,10 +18,6 @@ hosts:
     model: "avm_fritzbox-4040"
     wireless_profile: freifunk_default
     dhcp_no_ping: false
-    host__packages__to_merge:
-      - -tunnelmanager
-      - tunspace
-      - wireguard-tools
 
 ipv6_prefix: "2001:bf7:830:b100::/56"
 

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -25,12 +25,12 @@
     - luci-app-dawn
     - umdns
 
-- name: "Add tunnelmanager if configured"
+- name: "Add tunspace if configured"
   set_fact:
-    packages: "{{ packages + ['falter-berlin-tunnelmanager'] }}"
+    packages: "{{ packages + ['tunspace','wireguard-tools'] }}"
   when:
     - networks is defined
-    - networks | selectattr('tunnel_wan_ip', 'defined') | count > 0
+    - networks | selectattr('role', 'defined') | selectattr('role','equalto','tunnel') | count > 0
     - role == 'corerouter'
 
 - name: "Add zram-swap on low mem and big flash"


### PR DESCRIPTION
Everything migrated to tunspace. So remove tunnelmaner completely and use a rule to automatically add tunspace to packages instead like previous done for tunnelmanager.