### PR TITLE
Faster build times & little inventory fixes

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Building for $CHANGED_HOSTS"
           echo "CHANGED_HOSTS=$CHANGED_HOSTS" >> "$GITHUB_ENV"
           CHANGED_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/$BRANCH" | grep 'group_vars/location_' | sed 's/group_vars\/\(.*\)\/.*/\1/' | sort | uniq | sed -z 's/\n/,/g;s/,$//')
-          CHANGED_SINGE_FILE_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/master" | grep 'locations/' | sed 's/locations\/\(.*\)\.yml/location_\1/' | sed -z 's/\n/,/g;s/,$//')
+          CHANGED_SINGE_FILE_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/master" | grep 'locations/' | sed 's/locations\/\(.*\)\.yml/location_\1/' | sed -z 's/-/_/g;s/\n/,/g;s/,$//')
           CHANGED_LOCATIONS=${CHANGED_LOCATIONS:+$CHANGED_LOCATIONS,}$CHANGED_SINGE_FILE_LOCATIONS
           if [ -z "${CHANGED_LOCATIONS}" ]; then
             CHANGED_LOCATIONS="sama-core,sama-nord-nf-5ghz,l105-gw"

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -30,17 +30,21 @@ jobs:
           echo "Building for $CHANGED_HOSTS"
           echo "CHANGED_HOSTS=$CHANGED_HOSTS" >> "$GITHUB_ENV"
           CHANGED_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/$BRANCH" | grep 'group_vars/location_' | sed 's/group_vars\/\(.*\)\/.*/\1/' | sort | uniq | sed -z 's/\n/,/g;s/,$//')
-          CHANGED_SINGE_FILE_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/master" | grep 'locations/' | sed 's/locations\/\(.*\)\.yml/location_\1/' | sed -z 's/-/_/g;s/\n/,/g;s/,$//')
+          CHANGED_SINGE_FILE_LOCATIONS=$(git diff --diff-filter=d --name-only "origin/$BRANCH" | grep 'locations/' | sed 's/locations\/\(.*\)\.yml/location_\1/' | sed -z 's/-/_/g;s/\n/,/g;s/,$//')
           CHANGED_LOCATIONS=${CHANGED_LOCATIONS:+$CHANGED_LOCATIONS,}$CHANGED_SINGE_FILE_LOCATIONS
-          if [ -z "${CHANGED_LOCATIONS}" ]; then
-            CHANGED_LOCATIONS="sama-core,sama-nord-nf-5ghz,l105-gw"
+          CHANGED_OTHER=$(git diff --diff-filter=d --name-only "origin/$BRANCH" | grep -xP '(inventory|roles)/.+' | sed -z 's/\n/,/g;s/,$//')
+          if [ -z "${CHANGED_LOCATIONS}" ] && [ -n "${CHANGED_OTHER}" ]; then
+            CHANGED_LOCATIONS="sama-core,sama-nord-5ghz,l105-gw"
           fi
           echo "Building for $CHANGED_LOCATIONS"
           echo "CHANGED_LOCATIONS=$CHANGED_LOCATIONS" >> "$GITHUB_ENV"
 
       - name: Build changed locations
         run: |
-          ansible-playbook play.yml --tags image --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
+          if [ -n "${CHANGED_HOSTS}" ] || [ -n "${CHANGED_LOCATIONS}" ] ; then
+            ansible-playbook play.yml --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
+          fi
+          mkdir -p ./tmp/images
 
       - name: Store build output
         uses: actions/upload-artifact@v1

--- a/inventory/base_inventory
+++ b/inventory/base_inventory
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC2086
+# shellcheck disable=SC2002
 #
 # SC2086: Double quote to prevent globbing and word splitting.
 # - This one complained about an instance where double-quotes would lead to
 #   incorrect behaviour (`for i in $(seq ...)`). We do want the word splitting.
+# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# - Purely a question of aesthetic preference, I couldn't care less.
 
 set -e
 # set -x

--- a/inventory/base_inventory
+++ b/inventory/base_inventory
@@ -73,6 +73,10 @@ set -e
 # }
 #
 
+mkdir -p tmp/
+[ -f tmp/yj ] || wget -O tmp/yj -nv https://github.com/sclevine/yj/releases/download/v5.1.0/yj-linux-amd64
+chmod +x tmp/yj
+
 case "$1" in
 --host)
     query="$2"
@@ -83,10 +87,10 @@ case "$1" in
         locyml="locations/$tryloc.yml"
         if [ -f "$locyml" ] ; then
             # Location vars is location.yml without the hosts array.
-            locvars="$(yq -M -c 'del(.hosts)' "$locyml")"
+            locvars="$(cat "$locyml" | tmp/yj | jq -r 'del(.hosts)')"
             # Host vars is the matching object from the hosts array.
             # TODO: check that .location value matches filename
-            hostvars="$(yq -M -c '.hosts[] | select(.hostname == "'"$query"'")' "$locyml")"
+            hostvars="$(cat "$locyml" | tmp/yj | jq -r '.hosts[] | select(.hostname == "'"$query"'")')"
             if [ -z "$hostvars" ] ; then
                 echo "error: host $query not found in $locyml" >&2
                 exit 1
@@ -110,8 +114,10 @@ case "$1" in
     HOSTS=$(
         # TODO: check that .location value matches filename
         # TODO: check that hostname matches location name
-        for h in $(yq -M -r '.hosts[].hostname' locations/*.yml) ; do
-            echo -n '"'"$h"'", '
+        for f in locations/*.yml ; do
+            for h in $(cat "$f" | tmp/yj | jq -r '.hosts[].hostname'); do
+                echo -n '"'"$h"'", '
+            done
         done
         # Also look in Ansible's default location
         for h in host_vars/* ; do


### PR DESCRIPTION
- Make inventory a little bit faster (= half as slow). Singlefile locations are slow to parse because it's a new python interpreter for every single host. This gets worse the more locations we convert to singlefile format. `yj` is a golang tool which has much faster startup. I'm not happy adding a non-python dependency, but I want to make this faster right now make it "pretty" later. Ideally we'd rewrite the inventory script in python - not starting any new interpreters means no need for a golang tool.
- only build if actual code has changed, not for any non-code changes
- only build configs, not full images
  - this has been very time consuming and error prone when trying to merge PRs. we all have limited time and shouldn't spend it waiting for slow builds with limited value and reliability.
- Fix change detection for github worker testbuilds. The singlefile location filenames need to be turned into `location_foo_bar` tags. (fixes #661)
- fix test build AP hostname
- ~~Fix parzelle17-fritz location value.~~ (#690)