### PR TITLE
Include wikiupdater into testbuild action

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,6 +1,12 @@
 ---
 name: Test Build
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -39,14 +45,22 @@ jobs:
           echo "Building for $CHANGED_LOCATIONS"
           echo "CHANGED_LOCATIONS=$CHANGED_LOCATIONS" >> "$GITHUB_ENV"
 
-      - name: Build changed locations
+      - if: ${{ github.event_name == 'pull_request' }}
+        name: Build changed locations
         run: |
           if [ -n "${CHANGED_HOSTS}" ] || [ -n "${CHANGED_LOCATIONS}" ] ; then
             ansible-playbook play.yml --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
           fi
           mkdir -p ./tmp/images
 
-      - name: Store build output
+      - if: ${{ github.event_name == 'push' }}
+        name: Update wiki.freifunk.net
+        run: |
+          ansible-playbook play.yml --tags wiki --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
+        continue-on-error: true
+
+      - if: ${{ github.event_name == 'pull_request' }}
+        name: Store build output
         uses: actions/upload-artifact@v1
         with:
           name: ansibleimages

--- a/roles/cfg_openwrt/tasks/wikiupdater.yml
+++ b/roles/cfg_openwrt/tasks/wikiupdater.yml
@@ -8,7 +8,7 @@
 - name: wikiupdater | Generate outputfiles
   template:
     src: "templates/common/wikiupdater.j2"
-    dest: "{{ wikiupdater_dir }}/{{ group_names[0] | split('_') | last }}.txt"
+    dest: "{{ wikiupdater_dir }}/{{ location }}.txt"
     mode: "644"
 
 - name: wikiupdater | Update article

--- a/roles/cfg_openwrt/templates/common/wikiupdater.j2
+++ b/roles/cfg_openwrt/templates/common/wikiupdater.j2
@@ -92,13 +92,14 @@
 {# Printing wi.ki #}
 
 {# Makro for handling the print of lists#}
+{# converting everything to strings as github actions where otherwise complaining#}
 {% macro print(key,value)%}
     {% if value|type_debug == 'list'-%}
         {% for i in value -%}
-            |{{key}} = {{i}}
+            |{{key}} = {{i|string}}
         {% endfor %}
     {% else -%}
-        |{{key}} = {{value}}
+        |{{key}} = {{value|string}}
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
Make the wikiupdater skript automaticly updates wikiarticles when a push happens to `master`. This will help keeping our wiki always up to date. I added the option `continue-on-error: true` so we will go on if no wikiarticle was found. In addition I created credentials for a `bbbot`. They are stored inside this repo in the envirement called [wikiupdater](https://github.com/freifunk-berlin/bbb-configs/settings/environments/1751983185/edit)