### PR TITLE
model: Mikrotik Routerboard 750gr3 bump OpenWRT version

### DIFF
--- a/group_vars/model_mikrotik_routerboard_750gr3.yml
+++ b/group_vars/model_mikrotik_routerboard_750gr3.yml
@@ -1,6 +1,5 @@
 ---
 target: ramips/mt7621
-openwrt_version: 22.03-SNAPSHOT
 
 dsa_ports:
   - wan


### PR DESCRIPTION
this currently affects sgfrd-core and vaterhaus-core. We should flash this on sgfrd-core first, since it's easier to access if something goes wrong, but this is a mt7621 target, so I don't expect any issues.

@Petrella please test this on sgfrd-core.