### PR TITLE
parzelle17-fritz: fixed location name

### DIFF
--- a/locations/parzelle17-fritz.yml
+++ b/locations/parzelle17-fritz.yml
@@ -1,5 +1,5 @@
 ---
-location: parzelle17
+location: parzelle17-fritz
 location_nice: Parzelle 17
 latitude: 52.478675
 longitude: 13.471268


### PR DESCRIPTION
Testbuild fails due to handling of `-`, #670 would fix it