### PR TITLE
teufelsberg, vaterhaus: USBIP packages for Meshtastic node management

### DIFF
--- a/locations/teufelsberg.yml
+++ b/locations/teufelsberg.yml
@@ -18,6 +18,9 @@ hosts:
     role: corerouter
     model: linksys_e8450-ubi
     wireless_profile: freifunk_default
+    # USBIP packages to manage Meshtastic node (TLORA V1) connected via USB
+    host__packages__to_merge:
+      - "kmod-usb-ohci usbip-server usbip-client"
 
   - hostname: teufelsberg-ap1
     role: ap

--- a/locations/vaterhaus.yml
+++ b/locations/vaterhaus.yml
@@ -13,6 +13,9 @@ hosts:
   - hostname: vaterhaus-core
     role: corerouter
     model: "mikrotik_routerboard-750gr3"
+    # USBIP packages to manage Meshtastic node (HELTEC V1) connected via USB
+    host__packages__to_merge:
+      - "kmod-usb-ohci usbip-server usbip-client"
 
   - hostname: vaterhaus-n-nf-2ghz
     role: ap


### PR DESCRIPTION
There are Meshtastic nodes connected to the USB-Ports of the two core routers. By installing USBIP packages on the core-routers we can remotely manage and update these nodes to new firmware versions. This was tested and both Meshtastic nodes now run the newest firmware.