### PR TITLE
dragonkiez: 23.05 and single file format

### DIFF
--- a/group_vars/location_dragonkiez_adlerhalle/general.yml
+++ b/group_vars/location_dragonkiez_adlerhalle/general.yml
@@ -1,2 +1,0 @@
----
-community: true

--- a/group_vars/location_dragonkiez_adlerhalle/owm.yml
+++ b/group_vars/location_dragonkiez_adlerhalle/owm.yml
@@ -1,4 +1,0 @@
----
-location_nice: Dragonkiez Adlerhalle
-latitude: 52.495065429
-longitude: 13.387666941

--- a/group_vars/location_dragonkiez_adlerhalle/snmp.yml
+++ b/group_vars/location_dragonkiez_adlerhalle/snmp.yml
@@ -1,6 +1,0 @@
----
-
-snmp_devices:
-  - hostname: dragonkiez-adlerhalle-rhxb
-    address: 10.31.34.46
-    snmp_profile: airos_8

--- a/group_vars/location_dragonkiez_buero/general.yml
+++ b/group_vars/location_dragonkiez_buero/general.yml
@@ -1,2 +1,0 @@
----
-community: true

--- a/group_vars/location_dragonkiez_buero/owm.yml
+++ b/group_vars/location_dragonkiez_buero/owm.yml
@@ -1,4 +1,0 @@
----
-location_nice: Dragonkiezbuero
-latitude: 52.494722496
-longitude: 13.387774229

--- a/group_vars/location_dragonkiez_buero/snmp.yml
+++ b/group_vars/location_dragonkiez_buero/snmp.yml
@@ -1,6 +1,0 @@
----
-
-snmp_devices:
-  - hostname: dragonkiez-buero-rhxb
-    address: 10.31.23.114
-    snmp_profile: airos_8

--- a/group_vars/location_dragonkiez_dorfplatz/general.yml
+++ b/group_vars/location_dragonkiez_dorfplatz/general.yml
@@ -1,2 +1,0 @@
----
-community: true

--- a/group_vars/location_dragonkiez_dorfplatz/owm.yml
+++ b/group_vars/location_dragonkiez_dorfplatz/owm.yml
@@ -1,4 +1,0 @@
----
-location_nice: Dragonkiezdorfplatz
-latitude: 52.495457349
-longitude: 13.386079073

--- a/group_vars/location_dragonkiez_dorfplatz/snmp.yml
+++ b/group_vars/location_dragonkiez_dorfplatz/snmp.yml
@@ -1,6 +1,0 @@
----
-
-snmp_devices:
-  - hostname: dragonkiez-dorfplatz-rhxb
-    address: 10.31.28.250
-    snmp_profile: airos_8

--- a/group_vars/location_dragonkiez_kiezraum/general.yml
+++ b/group_vars/location_dragonkiez_kiezraum/general.yml
@@ -1,2 +1,0 @@
----
-community: true

--- a/group_vars/location_dragonkiez_kiezraum/owm.yml
+++ b/group_vars/location_dragonkiez_kiezraum/owm.yml
@@ -1,4 +1,0 @@
----
-location_nice: Dragonkiez Kiezraum
-latitude: 52.494807413
-longitude: 13.387511373

--- a/group_vars/location_dragonkiez_kiezraum/snmp.yml
+++ b/group_vars/location_dragonkiez_kiezraum/snmp.yml
@@ -1,6 +1,0 @@
----
-
-snmp_devices:
-  - hostname: dragonkiez-kiezraum-rhxb
-    address: 10.31.92.226
-    snmp_profile: airos_6

--- a/group_vars/location_dragonkiez_plangarage/general.yml
+++ b/group_vars/location_dragonkiez_plangarage/general.yml
@@ -1,2 +1,0 @@
----
-community: true

--- a/group_vars/location_dragonkiez_plangarage/owm.yml
+++ b/group_vars/location_dragonkiez_plangarage/owm.yml
@@ -1,4 +1,0 @@
----
-location_nice: Dragonkiez Plangarage
-latitude: 52.49550240409573
-longitude: 13.38777191534464

--- a/group_vars/location_dragonkiez_plangarage/snmp.yml
+++ b/group_vars/location_dragonkiez_plangarage/snmp.yml
@@ -1,6 +1,0 @@
----
-
-snmp_devices:
-  - hostname: dragonkiez-plangarage-rhxb
-    address: 10.31.92.98
-    snmp_profile: airos_6

--- a/group_vars/location_dragonkiez_rathausblock_miami/general.yml
+++ b/group_vars/location_dragonkiez_rathausblock_miami/general.yml
@@ -1,2 +1,0 @@
----
-community: true

--- a/group_vars/location_dragonkiez_rathausblock_miami/owm.yml
+++ b/group_vars/location_dragonkiez_rathausblock_miami/owm.yml
@@ -1,4 +1,0 @@
----
-location_nice: Dragonkiez Rathausblock Miami
-latitude: 52.495855798
-longitude: 13.387956619

--- a/group_vars/location_dragonkiez_rathausblock_miami/snmp.yml
+++ b/group_vars/location_dragonkiez_rathausblock_miami/snmp.yml
@@ -1,6 +1,0 @@
----
-
-snmp_devices:
-  - hostname: dragonkiez-rathausblock-miami-rhxb
-    address: 10.31.30.34
-    snmp_profile: airos_8

--- a/group_vars/model_ubnt_unifiac_mesh.yml
+++ b/group_vars/model_ubnt_unifiac_mesh.yml
@@ -1,9 +1,8 @@
 ---
 target: ath79/generic
-openwrt_version: 22.03-SNAPSHOT
 
 model__packages__to_merge:
-  - "-tcpdump -tmux -mtr -ethtool -iperf3 -curl -vnstat -kmod-ath10k-ct -ath10k-firmware-qca988x-ct"
+  - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"
   - "kmod-ath10k ath10k-firmware-qca988x"
 
 int_port: eth0

--- a/host_vars/dragonkiez-adlerhalle/base.yml
+++ b/host_vars/dragonkiez-adlerhalle/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-adlerhalle
-role: corerouter
-model: "ubnt_unifiac-mesh"
-
-wireless_profile: freifunk_default

--- a/host_vars/dragonkiez-buero/base.yml
+++ b/host_vars/dragonkiez-buero/base.yml
@@ -1,6 +1,0 @@
----
-
-location: dragonkiez-buero
-role: corerouter
-model: "siemens_ws-ap3610"
-wireless_profile: dragonkiez_buero

--- a/host_vars/dragonkiez-dorfplatz-ap1/base.yml
+++ b/host_vars/dragonkiez-dorfplatz-ap1/base.yml
@@ -1,5 +1,0 @@
----
-
-location: dragonkiez-dorfplatz
-role: ap
-model: "siemens_ws-ap3610"

--- a/host_vars/dragonkiez-dorfplatz/base.yml
+++ b/host_vars/dragonkiez-dorfplatz/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-dorfplatz
-role: corerouter
-model: "ubnt_unifiac-mesh"
-
-wireless_profile: freifunk_default

--- a/host_vars/dragonkiez-kiezraum/base.yml
+++ b/host_vars/dragonkiez-kiezraum/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-kiezraum
-role: corerouter
-model: "ubnt_unifiac-mesh"
-
-wireless_profile: freifunk_default

--- a/host_vars/dragonkiez-plangarage/base.yml
+++ b/host_vars/dragonkiez-plangarage/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-plangarage
-role: corerouter
-model: "ubnt_unifiac-mesh"
-
-wireless_profile: freifunk_default

--- a/host_vars/dragonkiez-rathausblock-miami-ap1/base.yml
+++ b/host_vars/dragonkiez-rathausblock-miami-ap1/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-rathausblock-miami
-role: ap
-model: "ubnt_unifiac-mesh"
-
-wireless_profile: freifunk_default

--- a/host_vars/dragonkiez-rathausblock-miami-ap2/base.yml
+++ b/host_vars/dragonkiez-rathausblock-miami-ap2/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-rathausblock-miami
-role: ap
-model: "ubnt_unifiac-mesh"
-
-wireless_profile: freifunk_default

--- a/host_vars/dragonkiez-rathausblock-miami/base.yml
+++ b/host_vars/dragonkiez-rathausblock-miami/base.yml
@@ -1,7 +1,0 @@
----
-
-location: dragonkiez-rathausblock-miami
-role: corerouter
-model: "ubnt_edgerouter-x-sfp"
-
-poe_on: [0, 1, 2]

--- a/locations/dragonkiez-adlerhalle.yml
+++ b/locations/dragonkiez-adlerhalle.yml
@@ -1,4 +1,21 @@
 ---
+location: dragonkiez-adlerhalle
+location_nice: Dragonkiez Adlerhalle
+latitude: 52.495065429
+longitude: 13.387666941
+community: true
+
+hosts:
+  - hostname: dragonkiez-adlerhalle
+    role: corerouter
+    model: "ubnt_unifiac-mesh"
+    wireless_profile: freifunk_default
+
+snmp_devices:
+  - hostname: dragonkiez-adlerhalle-rhxb
+    address: 10.31.34.46
+    snmp_profile: airos_8
+
 ipv6_prefix: "2001:bf7:830:b3c0::/58"
 
 # 10.31.177.160/27

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -1,4 +1,21 @@
 ---
+location: dragonkiez-buero
+location_nice: Dragonkiezbuero
+latitude: 52.494722496
+longitude: 13.387774229
+community: true
+
+hosts:
+  - hostname: dragonkiez-buero
+    role: corerouter
+    model: "siemens_ws-ap3610"
+    wireless_profile: dragonkiez_buero
+
+snmp_devices:
+  - hostname: dragonkiez-buero-rhxb
+    address: 10.31.23.114
+    snmp_profile: airos_8
+
 ipv6_prefix: "2001:bf7:830:b300::/58"
 
 # 10.31.177.160/27

--- a/locations/dragonkiez-dorfplatz.yml
+++ b/locations/dragonkiez-dorfplatz.yml
@@ -1,4 +1,24 @@
 ---
+location: dragonkiez-dorfplatz
+location_nice: Dragonkiezdorfplatz
+latitude: 52.495457349
+longitude: 13.386079073
+community: true
+
+hosts:
+  - hostname: dragonkiez-dorfplatz
+    role: corerouter
+    model: "ubnt_unifiac-mesh"
+    wireless_profile: freifunk_default
+  - hostname: dragonkiez-dorfplatz-ap1
+    role: ap
+    model: "siemens_ws-ap3610"
+
+snmp_devices:
+  - hostname: dragonkiez-dorfplatz-rhxb
+    address: 10.31.28.250
+    snmp_profile: airos_8
+
 ipv6_prefix: "2001:bf7:830:b340::/58"
 
 # 10.31.177.160/27

--- a/locations/dragonkiez-kiezraum.yml
+++ b/locations/dragonkiez-kiezraum.yml
@@ -1,4 +1,21 @@
 ---
+location: dragonkiez-kiezraum
+location_nice: Dragonkiez Kiezraum
+latitude: 52.494807413
+longitude: 13.387511373
+community: true
+
+hosts:
+  - hostname: dragonkiez-kiezraum
+    role: corerouter
+    model: "ubnt_unifiac-mesh"
+    wireless_profile: freifunk_default
+
+snmp_devices:
+  - hostname: dragonkiez-kiezraum-rhxb
+    address: 10.31.92.226
+    snmp_profile: airos_6
+
 ipv6_prefix: "2001:bf7:830:ad00::/56"
 
 # 10.31.92.192/26 2001:bf7:830:ad00::/56

--- a/locations/dragonkiez-plangarage.yml
+++ b/locations/dragonkiez-plangarage.yml
@@ -1,4 +1,21 @@
 ---
+location: dragonkiez-plangarage
+location_nice: Dragonkiez Plangarage
+latitude: 52.49550240409573
+longitude: 13.38777191534464
+community: true
+
+hosts:
+  - hostname: dragonkiez-plangarage
+    role: corerouter
+    model: "ubnt_unifiac-mesh"
+    wireless_profile: freifunk_default
+
+snmp_devices:
+  - hostname: dragonkiez-plangarage-rhxb
+    address: 10.31.92.98
+    snmp_profile: airos_6
+
 ipv6_prefix: "2001:bf7:830:3000::/56"
 
 # 10.31.92.64/26 2001:bf7:830:3000::/56

--- a/locations/dragonkiez-rathausblock-miami.yml
+++ b/locations/dragonkiez-rathausblock-miami.yml
@@ -1,4 +1,29 @@
 ---
+location: dragonkiez-rathausblock-miami
+location_nice: Dragonkiez Rathausblock Miami
+latitude: 52.495855798
+longitude: 13.387956619
+community: true
+
+hosts:
+  - hostname: dragonkiez-rathausblock-miami
+    role: corerouter
+    model: "ubnt_edgerouter-x-sfp"
+    poe_on: [0, 1, 2]
+  - hostname: dragonkiez-rathausblock-miami-ap1
+    role: ap
+    model: "ubnt_unifiac-mesh"
+    wireless_profile: freifunk_default
+  - hostname: dragonkiez-rathausblock-miami-ap2
+    role: ap
+    model: "ubnt_unifiac-mesh"
+    wireless_profile: freifunk_default
+
+snmp_devices:
+  - hostname: dragonkiez-rathausblock-miami-rhxb
+    address: 10.31.30.34
+    snmp_profile: airos_8
+
 ipv6_prefix: "2001:bf7:830:b380::/58"
 
 # Dragonerareal 2001:bf7:830:b300::/56


### PR DESCRIPTION
This PR switches the unifi ac mesh over to 23.05 as builds are broken with 22.03.
This PR converts dragonkiez to single file format.

Note: As we discovered just flashing unifi ac mesh devices remotely with this will brick the devices, as partitions are enlarged between OpenWRT releases. The devices therefore need to be updated manually at the location. The tested migration path is:

22.3-Freifunk -> 22.3-OpenWRT -> 23.5 OpenWRT -> 23.5-Freifunk