### PR TITLE
snmp_profiles: add SwOs and Edgeswitch

### DIFF
--- a/group_vars/all/snmp_profiles.yml
+++ b/group_vars/all/snmp_profiles.yml
@@ -179,3 +179,99 @@ collectd_snmp_profiles:
       TypeInstance: "TX Bitrate"
       Scale: 1000000
       Values: .1.3.6.1.4.1.14988.1.1.1.8.1.13.1
+
+  swos:
+    sys_uptime:
+      Type: uptime
+      TypeInstance: days
+      Table: false
+      Scale: 1.15740740741e-07
+      Values: .1.3.6.1.2.1.1.3.0
+
+    temp:
+      Type: temperature
+      TypeInstance: Celsius
+      Table: false
+      Scale: 0.1
+      Values: .1.3.6.1.4.1.14988.1.1.3.11.0
+
+    if_speed:
+      Type: bitrate
+      TypeInstanceOID: .1.3.6.1.2.1.17.1.4.1.1
+      Scale: 1000000
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.5
+
+    if_oper_status:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.17.1.4.1.1
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.8
+
+    if_in_errors:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.17.1.4.1.1
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.14
+
+# The CSS610-Series only runs SwOS Lite which have different OIDs at least for health
+  swos_lite:
+    sys_uptime:
+      Type: uptime
+      TypeInstance: days
+      Table: false
+      Scale: 1.15740740741e-07
+      Values: .1.3.6.1.2.1.1.3.0
+
+    temp:
+      Type: temperature
+      TypeInstance: Celsius
+      Table: false
+      Scale: 0.1
+      Values: .1.3.6.1.4.1.14988.1.1.3.100.1.3.52.0
+
+    if_speed:
+      Type: bitrate
+      TypeInstanceOID: .1.3.6.1.2.1.17.1.4.1.1
+      Scale: 1000000
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.5
+
+    if_oper_status:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.17.1.4.1.1
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.8
+
+    if_in_errors:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.17.1.4.1.1
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.14
+
+  edgeswitch:
+    sys_uptime:
+      Type: uptime
+      TypeInstance: days
+      Table: false
+      Scale: 1.15740740741e-07
+      Values: .1.3.6.1.2.1.1.8.0
+
+    if_oper_status:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.8
+
+    if_speed:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Scale: 1000000
+      Values: .1.3.6.1.2.1.2.2.1.5
+
+    if_in_errors:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.14

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -17,6 +17,9 @@ hosts:
       - "bird"
 
 snmp_devices:
+  - hostname: ak36-poe-roof
+    address: 10.31.130.131
+    snmp_profile: swos
 
   - hostname: ak36-philmel
     address: 10.31.130.132

--- a/locations/fesev.yml
+++ b/locations/fesev.yml
@@ -56,6 +56,10 @@ snmp_devices:
     address: 10.31.96.243
     snmp_profile: airos_8
 
+  - hostname: fesev-switch
+    address: 10.31.96.242
+    snmp_profile: edgeswitch
+
 # mesh: 10.31.96.216/30
 # dhcp: 10.31.97.128/25
 # mgmt: 10.31.96.240/28

--- a/locations/q216.yml
+++ b/locations/q216.yml
@@ -22,6 +22,10 @@ hosts:
     wireless_profile: freifunk_default
 
 snmp_devices:
+  - hostname: q216-switch
+    address: 10.31.201.242
+    snmp_profile: swos_lite
+
   - hostname: q216-tierpark
     address: 10.31.201.243
     snmp_profile: airos_8

--- a/locations/spitta13.yml
+++ b/locations/spitta13.yml
@@ -28,6 +28,10 @@ hosts:
     model: "mikrotik_sxtsq-5-ac"
 
 snmp_devices:
+  - hostname: spitta13-switch
+    address: 10.31.232.194
+    snmp_profile: swos
+
   - hostname: spitta13-zwingli
     address: 10.31.232.195
     snmp_profile: airos_8

--- a/roles/cfg_openwrt/templates/common/collectd/conf.d/bbb-snmp.conf.j2
+++ b/roles/cfg_openwrt/templates/common/collectd/conf.d/bbb-snmp.conf.j2
@@ -11,7 +11,7 @@ LoadPlugin snmp
   {% for metric_name,metric in collectd_snmp_profiles[profile_name].items() %}
     <Data "{{ profile_name }}_{{ metric_name }}">
     {% for opt,val in metric.items() %}
-        {{ opt }} {{ val|string|lower if val|string == 'True' or val|string =='False' or val is number else  "\"" + val|string + "\"" }} 
+        {{ opt }} {{ val|string|lower if val|string == 'True' or val|string =='False' or val is number else  "\"" + val|string + "\"" }}
     {% endfor %}
     </Data>
   {% endfor %}

--- a/roles/cfg_openwrt/templates/gateway/collectd/conf.d/bbb-snmp.conf.j2
+++ b/roles/cfg_openwrt/templates/gateway/collectd/conf.d/bbb-snmp.conf.j2
@@ -1,0 +1,1 @@
+../../../common/collectd/conf.d/bbb-snmp.conf.j2


### PR DESCRIPTION
This PR brings monitoring for Mikrotik SwitchOS and Ubiquitys Edgeswitches. In addition it fixes the monitoring of proprietary devices for our gateways.


- [x] Temperatur for SwOs
- [x] Uptime
- [x] Port Status
- [x] Add external SNMP monitoring to gateway devices (not rolled out yet as i didnt wanted to have unnecessary downtime at gateways)
- Fix Uptime Scale for Grafana freifunk-berlin/meta/issues/29
- Better Display Port Status in Grafana freifunk-berlin/meta/issues/29
- Better Display Port Speed in Gradana freifunk-berlin/meta/issues/29