### PR TITLE
Treewide: Add altitude attribute

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,9 +26,11 @@ location: magda # a string with the name of the location
 This part defines general values that are used e.g. in [Hopglass](https://hopglass.berlin.freifunk.net) and [OpenWifiMap](https://openwifimap.net).
 
 ```yml
-location_nice: roof top, Example-Street 24, 10573 Berlin        # any string that describes your location. It should contain an address.
+location_nice: roof top, Street 42, 10573 Berlin  # any string that describes your location. It should contain an address.
 latitude: 52.484948320
 longitude: 13.443380903
+altitude: 42                                      # in meter above sea level
+height: 13                                        # in meter above ground level
 ```
 
 ### contact details

--- a/group_vars/location_borussia/owm.yml
+++ b/group_vars/location_borussia/owm.yml
@@ -2,3 +2,4 @@
 location_nice: Borussiastraße
 latitude: 52.467250
 longitude: 13.377230
+altitude: 55

--- a/group_vars/location_gruni73/owm.yml
+++ b/group_vars/location_gruni73/owm.yml
@@ -3,3 +3,4 @@
 location_nice: Grünberger Str. 73
 latitude: 52.51147321097473
 longitude: 13.459692494247243
+altitude: 63

--- a/group_vars/location_gub37/owm.yml
+++ b/group_vars/location_gub37/owm.yml
@@ -2,3 +2,4 @@
 location_nice: gub37
 latitude: 52.51026648385623
 longitude: 13.45044163873424
+altitude: 54

--- a/group_vars/location_mahalle/owm.yml
+++ b/group_vars/location_mahalle/owm.yml
@@ -2,3 +2,4 @@
 location_nice: Waldemarstrasse 110
 latitude: 52.50099
 longitude: 13.42842
+altitude: 31

--- a/group_vars/location_wilgu10/owm.yml
+++ b/group_vars/location_wilgu10/owm.yml
@@ -2,3 +2,4 @@
 location_nice: Wihelm-Guddorf Straße 10
 latitude: 52.511307598350847
 longitude: 13.476963043212891
+altitude: 65

--- a/locations/agym.yml
+++ b/locations/agym.yml
@@ -4,6 +4,7 @@ location: agym
 location_nice: Andreas Gymnasium
 latitude: 52.514169
 longitude: 13.433311
+altitude: 67
 community: true
 
 hosts:

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -4,6 +4,7 @@ location: ak36
 location_nice: Alboinkontor
 latitude: 52.46558
 longitude: 13.369589
+altitude: 75
 community: true
 
 hosts:

--- a/locations/bht.yml
+++ b/locations/bht.yml
@@ -4,6 +4,7 @@ location: bht
 location_nice: Berliner Hochschule fuer Technik
 latitude: 52.544407831736
 longitude: 13.352562785148
+altitude: 88
 contact_nickname: 'Perry'
 contacts:
   - 'isprotejesvalkata [attt] gmail com'

--- a/locations/cafe-wostok.yml
+++ b/locations/cafe-wostok.yml
@@ -3,6 +3,7 @@ location: cafe-wostok
 location_nice: Café Wostok
 latitude: 52.502551833570074
 longitude: 13.494059451810992
+altitude: 32
 contacts:
   - "#freifunk-cafewostok:matrix.org"
 

--- a/locations/casa-kua.yml
+++ b/locations/casa-kua.yml
@@ -4,6 +4,7 @@ location: casa-kua
 location_nice: Casa Kuà
 latitude: 52.50134038554727
 longitude: 13.42292022730152
+altitude: 49
 community: true
 
 hosts:

--- a/locations/chris.yml
+++ b/locations/chris.yml
@@ -4,6 +4,7 @@ location: chris
 location_nice: Christophorus Kirche
 latitude: 52.541461
 longitude: 13.267025
+altitude: 65
 community: true
 
 hosts:

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -3,6 +3,7 @@ location: colbe15
 location_nice: Colbe15
 latitude: 52.513189
 longitude: 13.464245
+altitude: 50
 community: true
 
 hosts:

--- a/locations/dorfplatz.yml
+++ b/locations/dorfplatz.yml
@@ -4,6 +4,7 @@ location: dorfplatz
 location_nice: Dorfplatz
 latitude: 52.517924
 longitude: 13.457358
+altitude: 37
 community: true
 
 hosts:

--- a/locations/dragonkiez-adlerhalle.yml
+++ b/locations/dragonkiez-adlerhalle.yml
@@ -3,6 +3,8 @@ location: dragonkiez-adlerhalle
 location_nice: Dragonkiez Adlerhalle
 latitude: 52.495065429
 longitude: 13.387666941
+altitude: 35
+height: 2
 community: true
 
 hosts:

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -3,6 +3,8 @@ location: dragonkiez-buero
 location_nice: Dragonkiezbuero
 latitude: 52.494722496
 longitude: 13.387774229
+altitude: 35
+height: 2
 community: true
 
 hosts:

--- a/locations/dragonkiez-dorfplatz.yml
+++ b/locations/dragonkiez-dorfplatz.yml
@@ -3,6 +3,8 @@ location: dragonkiez-dorfplatz
 location_nice: Dragonkiezdorfplatz
 latitude: 52.495457349
 longitude: 13.386079073
+altitude: 35
+height: 2
 community: true
 
 hosts:

--- a/locations/dragonkiez-kiezraum.yml
+++ b/locations/dragonkiez-kiezraum.yml
@@ -3,6 +3,8 @@ location: dragonkiez-kiezraum
 location_nice: Dragonkiez Kiezraum
 latitude: 52.494807413
 longitude: 13.387511373
+altitude: 35
+height: 2
 community: true
 
 hosts:

--- a/locations/dragonkiez-plangarage.yml
+++ b/locations/dragonkiez-plangarage.yml
@@ -3,6 +3,8 @@ location: dragonkiez-plangarage
 location_nice: Dragonkiez Plangarage
 latitude: 52.49550240409573
 longitude: 13.38777191534464
+altitude: 37
+height: 2
 community: true
 
 hosts:

--- a/locations/dragonkiez-rathausblock-miami.yml
+++ b/locations/dragonkiez-rathausblock-miami.yml
@@ -3,6 +3,8 @@ location: dragonkiez-rathausblock-miami
 location_nice: Dragonkiez Rathausblock Miami
 latitude: 52.495855798
 longitude: 13.387956619
+altitude: 39
+height: 2
 community: true
 
 hosts:

--- a/locations/dtmb.yml
+++ b/locations/dtmb.yml
@@ -3,6 +3,7 @@ location: dtmb
 location_nice: Deutsches Technikmuseum
 latitude: 52.498579
 longitude: 13.378328
+altitude: 55
 community: true
 
 hosts:

--- a/locations/e16outdoor.yml
+++ b/locations/e16outdoor.yml
@@ -3,6 +3,7 @@ location: e16outdoor
 location_nice: 'Eberswalder Straße 16'
 latitude: 52.540810368412
 longitude: 13.408925450394
+altitude: 64
 contact_nickname: 'Noki'
 contacts:
   - '@noki-:matrix.org'

--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -3,6 +3,7 @@ location: emma
 location_nice: Emmauskirche
 latitude: 52.499825
 longitude: 13.431035
+altitude: 87
 community: true
 
 hosts:

--- a/locations/f17.yml
+++ b/locations/f17.yml
@@ -3,6 +3,7 @@ location: f17
 location_nice: Falckensteinstr 17
 latitude: 52.497630
 longitude: 13.441221
+altitude: 36
 contact_nickname: 'F17'
 contacts:
   - 'simon@imaginator.com'

--- a/locations/fanninger47.yml
+++ b/locations/fanninger47.yml
@@ -3,6 +3,7 @@ location: fanninger47
 location_nice: Rooftop, Fanningerstr 47, 10365 Berlin
 latitude: 52.51410
 longitude: 13.49858
+altitude: 63
 contacts:
   - '#fanninger47:matrix.org'
 

--- a/locations/fesev.yml
+++ b/locations/fesev.yml
@@ -4,6 +4,7 @@ location: fesev
 location_nice: Siegfriedstraße 183
 latitude: 52.5196117669
 longitude: 13.4988631290
+altitude: 71
 contact_nickname: 'Fes e.V. Freifunk AG'
 contacts:
   - 'fesev+freifunk@systemli.org'

--- a/locations/fffw-lebenshilfe.yml
+++ b/locations/fffw-lebenshilfe.yml
@@ -3,6 +3,7 @@ location: fffw-lebenshilfe
 location_nice: Lebenshilfe Oder-Spree, Wladimir-Komarow-Straße/Konstantin-E-Ziolkowksi-Ring, Fürstenwalde
 latitude: 52.370406
 longitude: 14.077577
+altitude: 43
 contact_name: 'Marc & Martin'
 contact_nickname: 'marcw & akira25'
 contacts:

--- a/locations/flughafen.yml
+++ b/locations/flughafen.yml
@@ -4,6 +4,7 @@ location: flughafen
 location_nice: Flughafen Tempelhof, Klosterstraße 68, 12249 Berlin
 latitude: 52.481937
 longitude: 13.390688
+altitude: 78
 community: true
 
 hosts:

--- a/locations/forcki.yml
+++ b/locations/forcki.yml
@@ -4,6 +4,7 @@ location: forcki
 location_nice: Forckenbeckplatz, 10249 Berlin
 latitude: 52.519112973573066
 longitude: 13.462383908075621
+altitude: 60
 community: true
 
 hosts:

--- a/locations/halle.yml
+++ b/locations/halle.yml
@@ -3,6 +3,7 @@ location: halle
 location_nice: Hallesches Tor
 latitude: 52.500323
 longitude: 13.393436
+altitude: 58
 contacts:
   - "Fxmanager@hotmail.com"
 

--- a/locations/huette15.yml
+++ b/locations/huette15.yml
@@ -4,6 +4,7 @@ location: huette15
 location_nice: Huette15
 latitude: 52.485032
 longitude: 13.447244
+altitude: 42
 contact_nickname: 'Packet Please'
 contacts:
   - 'pktpls@systemli.org'

--- a/locations/j41.yml
+++ b/locations/j41.yml
@@ -3,6 +3,7 @@ location: j41
 location_nice: Jessnerstraße 41
 latitude: 52.51047588
 longitude: 13.47179912
+altitude: 58
 community: true
 
 hosts:

--- a/locations/jup.yml
+++ b/locations/jup.yml
@@ -3,6 +3,7 @@ location: jup
 location_nice: Jup e.V.
 latitude: 52.565840
 longitude: 13.400220
+altitude: 63
 contact_nickname: 'Jup'
 contacts:
   - 'info@jup.berlin'

--- a/locations/k12.yml
+++ b/locations/k12.yml
@@ -3,6 +3,7 @@ location: k12
 location_nice: 'Kastanienallee 12, Haus 2'
 latitude: 52.53936534993554
 longitude: 13.409738833169316
+altitude: 63
 contact_nickname: 'zander'
 contacts:
   - 'alexanderjabs@gmx.de'

--- a/locations/k9.yml
+++ b/locations/k9.yml
@@ -3,6 +3,7 @@ location: k9
 location_nice: Kinzig9
 latitude: 52.51378093260403
 longitude: 13.466068518122656
+altitude: 60
 contact_nickname: 'K9 Freifunk Team'
 contacts:
   - 'freifunk@kinzig9.de'

--- a/locations/kiehl71.yml
+++ b/locations/kiehl71.yml
@@ -3,6 +3,7 @@ location: kiehl71
 location_nice: Kiehlufer 71
 latitude: 52.4842996651841
 longitude: 13.446898964621717
+altitude: 47
 contact_nickname: 'jammingblub'
 contacts:
   - 'koltonowski@protonmail.com'

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -3,6 +3,7 @@ location: kiehlufer
 location_nice: Kiehlufer
 latitude: 52.484348320
 longitude: 13.446680903
+altitude: 50
 contact_nickname: 'jammingblub'
 contacts:
   - 'warnmeldesystem@gmail.com'

--- a/locations/klunker.yml
+++ b/locations/klunker.yml
@@ -4,6 +4,7 @@ location: klunker
 location_nice: Klunkerkranich
 latitude: 52.4819617
 longitude: 13.4330485
+altitude: 63
 community: true
 
 hosts:

--- a/locations/koepi.yml
+++ b/locations/koepi.yml
@@ -4,6 +4,7 @@ location: koepi
 location_nice: koepi
 latitude: 52.507668
 longitude: 13.426087
+altitude: 52
 community: true
 
 hosts:

--- a/locations/kts13.yml
+++ b/locations/kts13.yml
@@ -3,6 +3,7 @@ location: kts13
 location_nice: Karpfenteichstraße 13
 latitude: 52.48232
 longitude: 13.46545
+altitude: 37
 contact_nickname: 'Packet Please'
 contacts:
   - 'pktpls@systemli.org'

--- a/locations/kub.yml
+++ b/locations/kub.yml
@@ -3,6 +3,7 @@ location: kub
 location_nice: KuB e.V. Berlin
 latitude: 52.50263
 longitude: 13.41339
+altitude: 47
 contact_nickname: 'KuB e.V.'
 contacts:
   - 'KuB e.V.'

--- a/locations/l105.yml
+++ b/locations/l105.yml
@@ -4,6 +4,7 @@ location: l105
 location_nice: Lützowstraße 105
 latitude: 52.502040
 longitude: 13.369420
+altitude: 62
 community: true
 
 hosts:

--- a/locations/l5.yml
+++ b/locations/l5.yml
@@ -3,6 +3,7 @@ location: l5
 location_nice: Lenaustraße 5
 latitude: 52.48995
 longitude: 13.42552
+altitude: 36
 contact_nickname: L5 Kollektiv
 contacts:
   - noc@stadtfunk.net

--- a/locations/liese-21.yml
+++ b/locations/liese-21.yml
@@ -4,6 +4,7 @@ location: liese-21
 location_nice: Frankfurter Allee 218
 latitude: 52.511259
 longitude: 13.49598
+altitude: 93
 contact_nickname: 'Hener'
 contacts:
   - 'ffhener@proton.me'

--- a/locations/linksfraktiontk.yml
+++ b/locations/linksfraktiontk.yml
@@ -3,6 +3,7 @@ location: linksfraktiontk
 location_nice: Linksfraktion Treptow Koepenick
 latitude: 52.483288177671
 longitude: 13.480247402648
+altitude: 48
 contact_nickname: 'Linksfraktion Treptow Koepenick'
 contacts:
   - 'mail@linksfraktion-treptow-koepenick.de'

--- a/locations/magda.yml
+++ b/locations/magda.yml
@@ -4,6 +4,7 @@ location: magda
 location_nice: Magdalenenstraße 19
 latitude: 52.514072806
 longitude: 13.488437533
+altitude: 60
 contacts:
   - '#ff-site-magda:matrix.org'
 

--- a/locations/manstein10.yml
+++ b/locations/manstein10.yml
@@ -3,6 +3,7 @@ location: manstein10
 location_nice: Manstein10
 latitude: 52.491872
 longitude: 13.366874
+altitude: 57
 contacts:
   - '365ff@systemli.org'
 

--- a/locations/mgh.yml
+++ b/locations/mgh.yml
@@ -4,6 +4,7 @@ location: mgh
 location_nice: Mehrgenerationenhaus Wassertorstraße
 latitude: 52.500439
 longitude: 13.405691
+altitude: 35
 community: true
 
 hosts:

--- a/locations/mlk-nk.yml
+++ b/locations/mlk-nk.yml
@@ -4,6 +4,7 @@ location: mlk-nk
 location_nice: Martin-Luther-Kirche Neukölln
 latitude: 52.484310005530894
 longitude: 13.43617358853226
+altitude: 64
 community: true
 
 hosts:

--- a/locations/ohlauer.yml
+++ b/locations/ohlauer.yml
@@ -4,6 +4,7 @@ location: ohlauer
 location_nice: Ohlauer
 latitude: 52.49378703855491
 longitude: 13.42969238683751
+altitude: 55
 community: true
 
 hosts:

--- a/locations/perleberger36.yml
+++ b/locations/perleberger36.yml
@@ -3,6 +3,7 @@ location: perleberger36
 location_nice: Heilige-Geist-Kirche Moabit
 latitude: 52.530674
 longitude: 13.346146
+altitude: 65
 contact_nickname: 'Perry'
 contacts:
   - 'isprotejesvalkata [attt] gmail.com'

--- a/locations/philmel.yml
+++ b/locations/philmel.yml
@@ -3,6 +3,7 @@ location: philmel
 location_nice: Philipp-Melanchthon-Kirche
 latitude: 52.465881
 longitude: 13.434112
+altitude: 83
 community: true
 
 hosts:

--- a/locations/potse.yml
+++ b/locations/potse.yml
@@ -3,6 +3,7 @@ location: potse
 location_nice: Potse
 latitude: 52.4835273
 longitude: 13.3902561
+altitude: 51
 contact_nickname: 'Potse'
 contacts:
   - 'potse_berlin@riseup.net'

--- a/locations/q216.yml
+++ b/locations/q216.yml
@@ -4,6 +4,7 @@ location: q216
 location_nice: Frankfurter Allee 216
 latitude: 52.51091
 longitude: 13.49417
+altitude: 68
 contact_nickname: Hener
 contacts:
   - ffhener@proton.me

--- a/locations/rauchhaus.yml
+++ b/locations/rauchhaus.yml
@@ -4,6 +4,7 @@ location: rauchhaus
 location_nice: rauchhaus
 latitude: 52.50481
 longitude: 13.42436
+altitude: 47
 community: true
 
 hosts:

--- a/locations/rhnk.yml
+++ b/locations/rhnk.yml
@@ -3,6 +3,7 @@ location: rhnk
 location_nice: Rathaus Neukoelln
 latitude: 52.481380
 longitude: 13.435078
+altitude: 90
 community: true
 
 hosts:

--- a/locations/rhxb.yml
+++ b/locations/rhxb.yml
@@ -4,6 +4,7 @@ location: rhxb
 location_nice: Rathaus Kreuzberg
 latitude: 52.493778
 longitude: 13.385290
+altitude: 74
 community: true
 
 hosts:

--- a/locations/rigaer78.yml
+++ b/locations/rigaer78.yml
@@ -3,6 +3,7 @@ location: rigaer78
 location_nice: Rigaerstraße 78
 latitude: 52.516646
 longitude: 13.464282
+altitude: 56
 community: true
 
 snmp_devices:

--- a/locations/rigaer83.yml
+++ b/locations/rigaer83.yml
@@ -4,6 +4,7 @@ location: rigaer83
 location_nice: Rigaerstraße 83
 latitude: 52.517060
 longitude: 13.461940
+altitude: 58
 community: true
 
 hosts:

--- a/locations/rio.yml
+++ b/locations/rio.yml
@@ -4,6 +4,7 @@ location: rio
 location_nice: Rio-Reiser-Platz
 latitude: 52.500355
 longitude: 13.423608
+altitude: 46
 community: true
 
 hosts:

--- a/locations/sama.yml
+++ b/locations/sama.yml
@@ -4,6 +4,7 @@ location: sama
 location_nice: Samariterkirche
 latitude: 52.518044835152963
 longitude: 13.466172516345976
+altitude: 77
 community: true
 
 hosts:

--- a/locations/sama27.yml
+++ b/locations/sama27.yml
@@ -3,6 +3,7 @@ location: sama27
 location_nice: Sama27
 latitude: 52.5188543341914
 longitude: 13.46564804132173
+altitude: 57
 contact_nickname: 'robertfoss'
 contacts:
   - 'me@robertfoss.se'

--- a/locations/scharni.yml
+++ b/locations/scharni.yml
@@ -3,6 +3,7 @@ location: scharni
 location_nice: Scharni
 latitude: 52.512702825706896
 longitude: 13.464007297614232
+altitude: 52
 community: true
 
 hosts:

--- a/locations/segen.yml
+++ b/locations/segen.yml
@@ -3,6 +3,7 @@ location: segen
 location_nice: Segenskirche
 latitude: 52.53604
 longitude: 13.41198
+altitude: 108
 contact_nickname: 'Perry'
 contacts:
   - 'isprotejesvalkata [attt] gmail.com'

--- a/locations/simeon.yml
+++ b/locations/simeon.yml
@@ -4,6 +4,7 @@ location: simeon
 location_nice: St.-Simeon-Kirche, Wassertorstraße 21, Berlin
 latitude: 52.500582
 longitude: 13.406656
+altitude: 105
 community: true
 
 hosts:

--- a/locations/sonnenblume.yml
+++ b/locations/sonnenblume.yml
@@ -3,6 +3,7 @@ location: sonnenblume
 location_nice: Wohngemeinschaft Sonnenblume
 latitude: 52.42718346824063
 longitude: 13.480034395635464
+altitude: 39
 contact_nickname: 'jammingblub'
 contacts:
   - 'koltonowski@protonmail.com'

--- a/locations/spitta13.yml
+++ b/locations/spitta13.yml
@@ -3,6 +3,7 @@ location: spitta13
 location_nice: Rooftop, Spittastraße 13, 10317 Berlin
 latitude: 52.50503
 longitude: 13.47959
+altitude: 49
 contacts:
   - '#spitta13:matrix.org'
 

--- a/locations/stadalbert.yml
+++ b/locations/stadalbert.yml
@@ -4,6 +4,7 @@ location: stadalbert
 location_nice: Torstr. 168
 latitude: 52.52867
 longitude: 13.39561
+altitude: 71
 contact_nickname: 'StAdalbert-FreifunkTeam'
 contacts:
   - 'noc@stadtfunk.net'

--- a/locations/strom.yml
+++ b/locations/strom.yml
@@ -4,6 +4,7 @@ location: strom
 location_nice: Stromstraße 2A
 latitude: 52.523268237
 longitude: 13.342632651
+altitude: 55
 community: true
 
 hosts:

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -3,6 +3,7 @@ location: suedblock
 location_nice: Suedblock
 latitude: 52.498599118
 longitude: 13.416844010
+altitude: 33
 contact_nickname: '365ff'
 contacts:
   - '365ff [ät] systemli [dot] org'

--- a/locations/teufelsberg.yml
+++ b/locations/teufelsberg.yml
@@ -4,6 +4,7 @@ location: teufelsberg
 location_nice: Teufelsberg
 latitude: 52.49800
 longitude: 13.24052
+altitude: 151
 community: true
 
 # 10.31.213.0/24

--- a/locations/vaterhaus.yml
+++ b/locations/vaterhaus.yml
@@ -4,6 +4,7 @@ location: vaterhaus
 location_nice: Kirche Zum Vaterhaus, Baumschulenstraße 82-83, 12437 Berlin
 latitude: 52.4649
 longitude: 13.4852
+altitude: 72
 contact_nickname: 'xayax'
 contacts:
   - 'ff@xayax.de'

--- a/locations/walde.yml
+++ b/locations/walde.yml
@@ -4,6 +4,7 @@ location: walde
 location_nice: Waldemarstrasse 103
 latitude: 52.501329204
 longitude: 13.427798152
+altitude: 47
 community: true
 
 hosts:

--- a/locations/xdorf.yml
+++ b/locations/xdorf.yml
@@ -4,6 +4,7 @@ location: xdorf
 location_nice: xdorf
 latitude: 52.504855
 longitude: 13.424628
+altitude: 40
 community: true
 
 hosts:

--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -3,6 +3,7 @@ location: zwingli
 location_nice: Zwinglikirche, Rudolfstraße 14, 10245 Berlin
 latitude: 52.5035417
 longitude: 13.4547472
+altitude: 77
 community: true
 
 hosts:

--- a/roles/cfg_openwrt/templates/common/wikiupdater.j2
+++ b/roles/cfg_openwrt/templates/common/wikiupdater.j2
@@ -16,6 +16,8 @@
     'location_nice',
     'latitude',
     'longitude',
+    'altitude',
+    'height',
     'ipv6_prefix'
     ]%}
 {% for i in attributes %}


### PR DESCRIPTION
This will help with further automating the documentation like wiki, locationpages at our website or uisp.

- [x] rename height to altitude
- [x] Explain in README [altitude vs height](https://en.wikipedia.org/wiki/Altitude#/media/File:Vertical_distances.svg)