### PR TITLE
Treewide: Add snmp monitoring for some switches

### DIFF
--- a/group_vars/all/snmp_profiles.yml
+++ b/group_vars/all/snmp_profiles.yml
@@ -92,6 +92,8 @@ collectd_snmp_profiles:
       TypeInstanceOID: .1.3.6.1.4.1.41112.1.4.7.1.2.1
       Values: .1.3.6.1.4.1.41112.1.4.7.1.20.1
 
+  # Collectd will throw a noSuchName error every Interval for every Value
+  # when no Station is connected to a AP
   airos_6:
     sys_uptime:
       Type: uptime

--- a/group_vars/all/snmp_profiles.yml
+++ b/group_vars/all/snmp_profiles.yml
@@ -274,3 +274,58 @@ collectd_snmp_profiles:
       TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
       Table: true
       Values: .1.3.6.1.2.1.2.2.1.14
+
+  edgerouter:
+    sys_uptime:
+      Type: uptime
+      TypeInstance: days
+      Table: false
+      Scale: 1.15740740741e-07 # TODO: Check scale
+      Values: 1.3.6.1.2.1.25.1.1.0
+
+    if_oper_status:
+      Type: gauge
+      TypeInstanceOID: 1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.8
+
+    if_speed:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Scale: 1000000
+      Values: 1.3.6.1.2.1.2.2.1.5
+
+    if_in_errors:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.14
+
+
+  tplink:
+    sys_uptime:
+      Type: uptime
+      TypeInstance: days
+      Table: false
+      Scale: 1.15740740741e-07 # TODO: check if scale if right. Unit is 1/100th of a second
+      Values: .1.3.6.1.2.1.1.3
+
+    if_oper_status:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Values: 1.3.6.1.2.1.2.2.1.8
+
+    if_speed:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Scale: 1000000
+      Values: 1.3.6.1.2.1.2.2.1.5
+
+    if_in_errors:
+      Type: gauge
+      TypeInstanceOID: .1.3.6.1.2.1.2.2.1.2
+      Table: true
+      Values: .1.3.6.1.2.1.2.2.1.14

--- a/group_vars/all/snmp_profiles.yml
+++ b/group_vars/all/snmp_profiles.yml
@@ -302,7 +302,6 @@ collectd_snmp_profiles:
       Table: true
       Values: .1.3.6.1.2.1.2.2.1.14
 
-
   tplink:
     sys_uptime:
       Type: uptime

--- a/locations/agym.yml
+++ b/locations/agym.yml
@@ -15,6 +15,10 @@ hosts:
     wireless_profile: freifunk_default
 
 snmp_devices:
+  - hostname: agym-switch-roof
+    address: 10.230.89.2
+    snmp_profile: edgeswitch
+
   - hostname: agym-zwingli
     address: 10.230.89.4
     snmp_profile: af60

--- a/locations/chris.yml
+++ b/locations/chris.yml
@@ -31,6 +31,10 @@ hosts:
     model: "ubnt_nanostation-m2_xm"
 
 snmp_devices:
+  - hostname: chris-switch
+    address: 10.230.18.2
+    snmp_profile: tplink
+
   - hostname: chris-bht
     address: 10.230.18.3
     snmp_profile: airos_6

--- a/locations/dorfplatz.yml
+++ b/locations/dorfplatz.yml
@@ -37,6 +37,10 @@ hosts:
     model: "avm_fritzbox-4040"
 
 snmp_devices:
+  - hostname: dorfplatz-poe-switch
+    address: 10.31.75.34
+    snmp_profile: edgeswitch
+
   - hostname: dorfplatz-sama
     address: 10.31.75.35
     snmp_profile: airos_8

--- a/locations/dtmb.yml
+++ b/locations/dtmb.yml
@@ -14,6 +14,14 @@ hosts:
     wireless_profile: freifunk_default
 
 snmp_devices:
+  - hostname: dtmb-sw1
+    address: 10.31.131.2
+    snmp_profile: edgeswitch
+
+  - hostname: dtmb-sw2
+    address: 10.31.131.3
+    snmp_profile: edgeswitch
+
   - hostname: dtmb-ak36
     address: 10.31.131.10
     snmp_profile: airos_6

--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -61,11 +61,6 @@ snmp_devices:
     address: 10.31.11.25
     snmp_profile: airos_8
 
-  # Monitor ohlauer device from emma until monitoring at ohlauer is deployed
-  - hostname: ohlauer-emma
-    address: 10.31.166.251
-    snmp_profile: mikrotik_60g
-
 airos_dfs_reset:
   - name: "emma-oso-5ghz"
     target: "10.31.11.19"

--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -13,31 +13,55 @@ hosts:
     wireless_profile: freifunk_default
 
 snmp_devices:
+  - hostname: emma-switch-no
+    address: 10.31.11.2
+    snmp_profile: edgeswitch
+
+  - hostname: emma-switch-so
+    address: 10.31.11.3
+    snmp_profile: edgeswitch
+
+  - hostname: emma-switch-sw
+    address: 10.31.11.4
+    snmp_profile: edgeswitch
+
+  - hostname: emma-switch-nw
+    address: 10.31.11.5
+    snmp_profile: edgeswitch
+
   - hostname: emma-ssw-uplink
     address: 10.31.11.18
     snmp_profile: mikrotik_60g
+
   - hostname: emma-oso-5ghz
     address: 10.31.11.19
     snmp_profile: airos_8
+
   - hostname: emma-nno-5ghz
     address: 10.31.11.20
     snmp_profile: airos_8
+
   - hostname: emma-ono-5ghz
     address: 10.31.11.21
     snmp_profile: airos_8
+
   - hostname: emma-wsw-5ghz
     address: 10.31.11.22
     snmp_profile: airos_8
+
   - hostname: emma-wnw-5ghz
     address: 10.31.11.23
     snmp_profile: airos_8
+
   - hostname: emma-nnw-5ghz
     address: 10.31.11.24
     snmp_profile: airos_8
+
   - hostname: emma-sso-5ghz
     address: 10.31.11.25
     snmp_profile: airos_8
-  # Monitor ohlauer device from emma
+
+  # Monitor ohlauer device from emma until monitoring at ohlauer is deployed
   - hostname: ohlauer-emma
     address: 10.31.166.251
     snmp_profile: mikrotik_60g

--- a/locations/gruni73.yml
+++ b/locations/gruni73.yml
@@ -27,6 +27,10 @@ hosts:
     model: "ubnt_rocket-5ac-lite"
 
 snmp_devices:
+  - hostname: gruni73-switch
+    address: 10.31.156.2
+    snmp_profile: edgeswitch
+
   - hostname: gruni73-sama
     address: 10.31.156.5
     snmp_profile: airos_8

--- a/locations/j41.yml
+++ b/locations/j41.yml
@@ -13,6 +13,10 @@ hosts:
     wireless_profile: freifunk_default
 
 snmp_devices:
+  - hostname: j41-switch
+    address: 10.31.41.2
+    snmp_profile: edgeswitch
+
   - hostname: j41-f2a
     address: 10.31.41.3
     snmp_profile: airos_6

--- a/locations/jup.yml
+++ b/locations/jup.yml
@@ -13,29 +13,40 @@ hosts:
     role: corerouter
     model: "tplink_tl-wdr4900-v1"
     wireless_profile: freifunk_default
+
   - hostname: jup-m5-ap1
     role: ap
     model: "ubnt_nanostation-m5_xm"
+
   - hostname: jup-m5-ap2
     role: ap
     model: "ubnt_nanostation-m5_xm"
+
   - hostname: jup-m2-ap3
     role: ap
     model: "ubnt_nanostation-m2_xm"
+
   - hostname: jup-bullet-ap4
     role: ap
     model: "ubnt_bullet-m-ar7241"
+
   - hostname: jup-m5-ap5
     role: ap
     model: "ubnt_nanostation-m5_xm"
+
   - hostname: jup-bar
     role: ap
     model: "avm_fritzbox-7530"
 
 snmp_devices:
+  - hostname: jup-poe
+    address: 10.31.147.130
+    snmp_profile: edgeswitch
+
   - hostname: jup-bht
     address: 10.31.147.131
     snmp_profile: airos_6
+
   - hostname: jup-segen
     address: 10.31.147.132
     snmp_profile: airos_6

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -61,6 +61,9 @@ hosts:
       eth0: 08:55:31:b1:3c:01
 
 snmp_devices:
+  - hostname: kiehlufer-switch
+    address: 10.31.82.210
+    snmp_profile: swos_lite
 
   - hostname: kiehlufer-rhnk
     address: 10.31.82.211

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -7,19 +7,6 @@ longitude: 13.44337
 contact_nickname: Stadtfunk gGmbH
 contacts:
   - noc@stadtfunk.net
-location__ssh_keys__to_merge:
-  - comment: pktpls@systemli.org
-    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINVY2XHiLDXbj7TGWtUpKEb8+qKw/DrkiVbLiyvyRaCi
-  - comment: Hener
-    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEST9QsXtphN7BYb5p9FhxZTxvoWkICfRWC54SN/QHII
-  - comment: Lino
-    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOaljQHr4Nj6veeDi51BZjy/a3WXP
-
-# 10.31.183.128/28 - mgmt     - vlan 42
-# 10.31.183.144/28 - mesh     - vlan 20, 50
-# 10.31.183.160/27 - privdhcp - vlan 41 untagged
-# 10.31.183.192/26 - dhcp     - vlan 40
-ipv6_prefix: 2001:bf7:820:2300::/56
 
 hosts:
 
@@ -49,6 +36,12 @@ hosts:
     model: mikrotik_sxtsq-5-ac
     mac_override: {eth0: 2c:c8:1b:8a:96:28}
     wireless_profile: freifunk_default
+
+# 10.31.183.128/28 - mgmt     - vlan 42
+# 10.31.183.144/28 - mesh     - vlan 20, 50
+# 10.31.183.160/27 - privdhcp - vlan 41 untagged
+# 10.31.183.192/26 - dhcp     - vlan 40
+ipv6_prefix: 2001:bf7:820:2300::/56
 
 networks:
 

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -37,6 +37,11 @@ hosts:
     mac_override: {eth0: 2c:c8:1b:8a:96:28}
     wireless_profile: freifunk_default
 
+snmp_devices:
+  - hostname: kirchhof-switch
+    address: 10.31.147.130
+    snmp_profile: edgeswitch
+
 # 10.31.183.128/28 - mgmt     - vlan 42
 # 10.31.183.144/28 - mesh     - vlan 20, 50
 # 10.31.183.160/27 - privdhcp - vlan 41 untagged

--- a/locations/klunker.yml
+++ b/locations/klunker.yml
@@ -1,5 +1,4 @@
 ---
-
 location: klunker
 location_nice: Klunkerkranich
 latitude: 52.4819617
@@ -8,7 +7,6 @@ altitude: 63
 community: true
 
 hosts:
-
   - hostname: klunker-core
     role: corerouter
     model: "avm_fritzbox-4040"
@@ -33,9 +31,14 @@ hosts:
       eth0: cc:2d:e0:9c:4f:00
 
 snmp_devices:
+  - hostname: klunker-switch
+    address: 10.31.191.178
+    snmp_profile: edgeswitch
+
   - hostname: klunker-rhnk
     address: 10.31.191.179
     snmp_profile: mikrotik_60g
+
   - hostname: klunker-philmel
     address: 10.31.191.180
     snmp_profile: af60

--- a/locations/l105.yml
+++ b/locations/l105.yml
@@ -1,5 +1,4 @@
 ---
-
 location: l105
 location_nice: Lützowstraße 105
 latitude: 52.502040
@@ -8,13 +7,27 @@ altitude: 62
 community: true
 
 hosts:
-
   - hostname: l105-gw
     role: gateway
     model: "x86-64"
     image_search_pattern: "*-ext4-combined.img*"
     l105__disabled_services__to_merge:
       - "bird"
+
+snmp_devices:
+  - hostname: l105-poe
+    address: 10.31.127.130
+    snmp_profile: edgeswitch
+
+  - hostname: l105-rhxb
+    address: 10.31.127.131
+    snmp_profile: af60
+
+  # tub is not existent as of 02/24
+  # - hostname: l105-tu
+  #   adress: 10.31.127.132
+  #   snmp_profile: af60
+
 
 # L105 got following prefixes:
 # Router: 10.31.127.128/25 2001:bf7:750:3f00::/56
@@ -38,9 +51,9 @@ mgmt:
   ipv6: 2001:bf7:750:3f00::/64
   assignments:
     l105-gw: 1    # .129
-    l105-poe: 2   # .130 poe
-    l105-rhxb: 3  # .131 mesh_rhxb
-    l105-tu: 4    # .132 mesh_tu
+    l105-poe: 2   # .130
+    l105-rhxb: 3  # .131
+    l105-tu: 4    # .132
 
 # Mesh Network: 10.31.127.160/27
 mesh_links:

--- a/locations/l105.yml
+++ b/locations/l105.yml
@@ -53,7 +53,7 @@ mgmt:
     l105-gw: 1    # .129
     l105-poe: 2   # .130
     l105-rhxb: 3  # .131
-    l105-tu: 4    # .132
+    # l105-tu: 4    # .132
 
 # Mesh Network: 10.31.127.160/27
 mesh_links:
@@ -64,12 +64,12 @@ mesh_links:
     metric: 128
     ptp: true
 
-  - name: mesh_tu
-    ifname: eth1.11
-    ipv4: 10.31.127.161/32
-    ipv6: 2001:bf7:750:3f01::2/128
-    metric: 128
-    ptp: true
+  # - name: mesh_tu
+  #   ifname: eth1.11
+  #   ipv4: 10.31.127.161/32
+  #   ipv6: 2001:bf7:750:3f01::2/128
+  #   metric: 128
+  #   ptp: true
 
   - name: mesh_bbbvpn
     ifname: eth1.32

--- a/locations/l5.yml
+++ b/locations/l5.yml
@@ -9,7 +9,6 @@ contacts:
   - noc@stadtfunk.net
 
 hosts:
-
   - hostname: l5-core
     role: corerouter
     model: "avm_fritzbox-4040"
@@ -27,6 +26,11 @@ hosts:
     mac_override:
       eth0: dc:2c:6e:c4:35:e9
 
+snmp_devices:
+  - hostname: l5-switch
+    address: 10.31.161.162
+    snmp_profile: edgeswitch
+
 # 10.31.161.160/29 - mgmt
 # 10.31.191.160/29 - mesh
 # 10.31.194.0/25 - dhcp
@@ -34,7 +38,6 @@ hosts:
 ipv6_prefix: "2001:bf7:830:b600::/56"
 
 networks:
-
   - vid: 40
     role: dhcp
     name: dhcp

--- a/locations/ohlauer.yml
+++ b/locations/ohlauer.yml
@@ -13,6 +13,15 @@ hosts:
     role: gateway
     model: "ubnt_edgerouter-4"
 
+snmp_devices:
+  - hostname: ohlauer-switch
+    address: 10.31.166.250
+    snmp_profile: edgerouter
+
+  - hostname: ohlauer-emma
+    address: 10.31.166.251
+    snmp_profile: mikrotik_60g
+
 ipv6_prefix: 2001:bf7:830:8300::/56
 
 # mgmt: 10.31.166.248/29

--- a/locations/saarbruecker.yml
+++ b/locations/saarbruecker.yml
@@ -1,5 +1,4 @@
 ---
-
 location: saarbruecker
 location_nice: Saarbrücker
 latitude: 52.5283930134242
@@ -7,10 +6,27 @@ longitude: 13.41561550087894
 community: true
 
 hosts:
-
   - hostname: saarbruecker-gw
     role: gateway
     model: "ubnt_edgerouter-4"
+
+snmp_devices:
+  - hostname: saarbruecker-sw
+    address: 10.31.83.50
+    snmp_profile: edgerouter
+
+  - hostname: saarbruecker-hds
+    address: 10.31.83.51
+    snmp_profile: mikrotik_60g
+
+  - hostname: saarbruecker-sama
+    address: 10.31.83.52
+    snmp_profile: af60
+
+  # Despite being a 60GHz devices the SNMP-data that is reported is in the same format as the airmax devices
+  - hostname: saarbruecker-segen
+    address: 10.31.83.53
+    snmp_profile: airos_8
 
 ipv6_prefix: 2001:bf7:760:2201::/56
 

--- a/locations/sama.yml
+++ b/locations/sama.yml
@@ -38,6 +38,14 @@ hosts:
       eth0: 08:55:31:54:63:06
 
 snmp_devices:
+  - hostname: sama-poe-1
+    address: 10.31.81.2
+    snmp_profile: edgeswitch
+
+  - hostname: sama-poe-2
+    address: 10.31.81.3
+    snmp_profile: edgeswitch
+
   - hostname: sama-nord-5ghz
     address: 10.31.81.20
     snmp_profile: airos_8
@@ -56,10 +64,6 @@ snmp_devices:
 
   - hostname: sama-sued-60ghz
     address: 10.31.81.26
-    snmp_profile: af60
-
-  - hostname: saarbruecker-sama
-    address: 10.31.83.52
     snmp_profile: af60
 
   - hostname: sama-saarbruecker

--- a/locations/segen.yml
+++ b/locations/segen.yml
@@ -32,10 +32,14 @@ hosts:
     model: ubnt_nanostation-m2_xm
 
 snmp_devices:
-  # TODO: Create a Gigabeam LR SNMP profile and use it for segen-saarbr
-  # - hostname: segen-saarbr
-  #   address: 10.31.6.10
-  #   snmp_profile: airos_8
+  - hostname: segen-switch
+    address: 10.31.6.2
+    snmp_profile: edgeswitch
+
+  # Despite being a 60GHz devices the SNMP-data that is reported is in the same format as the airmax devices
+  - hostname: segen-saarbr
+    address: 10.31.6.10
+    snmp_profile: airos_8
 
   - hostname: segen-f2a
     address: 10.31.6.11

--- a/locations/strom.yml
+++ b/locations/strom.yml
@@ -25,6 +25,9 @@ hosts:
       - ethtool -K eth0 tx off rx off
 
 snmp_devices:
+  - hostname: strom-poe
+    address: 10.31.130.66
+    snmp_profile: tplink
 
   - hostname: strom-perleberger
     address: 10.31.130.67


### PR DESCRIPTION
This PR adds Monitoring for some switches and several new profiles to archive this. These changes got already deployed at the gateways. Grafana/cgp arent yet at the state of showing all of these values in a beautifull way but this shouldnt stop us from slowly rolling out more data collection from the switches.

Although i didnt touched it Im unhappy about the current `airos_6` Situation. When no Station is connected  to a AirOS 6 AP the snmp-call for the name of the connected stations obviously cant work resulting in a NoSuchName-Error in our logs. This means that we get at e.g. `chris-core` every 30 seconds 30 errors. We should address this in the future. #766 

TODOs:
- [x] Add Profile for tplink
- [x] Add Profile for edgerouter
- [x] Add + Deploy Monitoring for ak36
- [x] Add + Deploy Monitoring for l105
- [x] Add + Deploy Monitoring for ohlauer
- [x] Add + Deploy Monitoring for saarbruecker
  - [x] Remove saarbruecker-sama monitoring from sama
  - [x] ~~Add profile for Gigabeam LR and add monitoring (also on segen)~~ use airos_8 profile as the missing data doesnt get reported. We get zeros as a reply which is handable.
- [x] Add + Deploy Monitoring for strom
- [x] Investigate the NoSuchName Error on airos_6 devices -> Solution #766 
  - [x] Investigate if we can compress this error
  - [x] ~~If not~~ write a comment
- [x] Check Scales -> need to be fixed somewhere else. The wrong scale only happens at Grafana. This is because the script feeding prometheus doesn't hand over the scale Information's if i understood rtznmpfl correctly
- [x] Make shure that snmp is correctly configured on all ~~hosts~~ gateway devices