### PR TITLE
workflows: fix wikiupdate and bump version to v4

### DIFF
--- a/.github/workflows/configrun.yml
+++ b/.github/workflows/configrun.yml
@@ -1,5 +1,5 @@
 ---
-name: Test Build
+name: Config Run
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Ansible Test Build
+    name: Ansible Config Run
     runs-on: ubuntu-latest
 
     steps:
@@ -50,10 +50,10 @@ jobs:
           if [ -n "${CHANGED_HOSTS}" ] || [ -n "${CHANGED_LOCATIONS}" ] ; then
             ansible-playbook play.yml --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
           fi
-          mkdir -p ./tmp/images
+          mkdir -p ./tmp/configs
 
       - name: Store build output
         uses: actions/upload-artifact@v1
         with:
-          name: ansibleimages
-          path: ./tmp/images
+          name: ansibleconfigs
+          path: ./tmp/configs

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,7 +42,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper
           # list of changed files within `super-linter`

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,6 +1,6 @@
 ---
 name: Test Build
-on: [pull_request] # yamllint disable-line rule:truthy
+on: [pull_request]  # yamllint disable-line rule:truthy
 
 jobs:
   build:

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,12 +1,6 @@
 ---
 name: Test Build
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [pull_request] # yamllint disable-line rule:truthy
 
 jobs:
   build:
@@ -45,22 +39,14 @@ jobs:
           echo "Building for $CHANGED_LOCATIONS"
           echo "CHANGED_LOCATIONS=$CHANGED_LOCATIONS" >> "$GITHUB_ENV"
 
-      - if: ${{ github.event_name == 'pull_request' }}
-        name: Build changed locations
+      - name: Build changed locations
         run: |
           if [ -n "${CHANGED_HOSTS}" ] || [ -n "${CHANGED_LOCATIONS}" ] ; then
             ansible-playbook play.yml --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
           fi
           mkdir -p ./tmp/images
 
-      - if: ${{ github.event_name == 'push' }}
-        name: Update wiki.freifunk.net
-        run: |
-          ansible-playbook play.yml --tags wiki --limit "${CHANGED_HOSTS:+$CHANGED_HOSTS,}$CHANGED_LOCATIONS"
-        continue-on-error: true
-
-      - if: ${{ github.event_name == 'pull_request' }}
-        name: Store build output
+      - name: Store build output
         uses: actions/upload-artifact@v1
         with:
           name: ansibleimages

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -1,6 +1,12 @@
 ---
 name: Test Build
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/wikiupdate.yml
+++ b/.github/workflows/wikiupdate.yml
@@ -1,0 +1,35 @@
+---
+name: Wikiupdate
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: sudo apt install python3
+
+      - name: Install dependencies
+        run: pip3 install -r requirements.txt --upgrade pip
+
+      - name: Determine changed locations
+        run: |
+            CHANGED_LOCATIONS=$(git diff ${{ github.event.before }}..${{ github.event.after }} --diff-filter=d --name-only | grep 'locations/' | sed 's/locations\/\(.*\)\.yml/location_\1/' | sed -z 's/-/_/g;s/\n/,/g;s/,$//')
+            echo "Updating for changed locations: $CHANGED_LOCATIONS"
+            echo "CHANGED_LOCATIONS=$CHANGED_LOCATIONS" >> "$GITHUB_ENV"
+
+      - name: Update wiki.freifunk.net
+        run: |
+          if [ -n "${CHANGED_LOCATIONS}" ]; then
+            ansible-playbook play.yml --tags wiki --limit "$CHANGED_LOCATIONS" ||true
+          else
+            echo "No locations were changed. Skipping update"
+          fi


### PR DESCRIPTION
Move the wikiupdate-workflow into a independent file making it way more clean. And it is working now as intended (instead of building all locations) as you can see here
[with a changed location](https://github.com/FFHener/bbb-configs/actions/runs/7807563218/job/21296175674)
[without a changed location ](https://github.com/FFHener/bbb-configs/actions/runs/7807593320/job/21296262014)

I use `||true` so the task will never fail because there might be locations that doesn't get updated because they don't have a wikiarticle.

In addition i bumped the version of `actions/checkout@v3` to v4 as the old one was using Node.js 16 which is deprecated.