### PR TITLE
templates: deactivate stderr of collectd if it monitors airos_6

### DIFF
--- a/roles/cfg_openwrt/templates/common/rc.local.j2
+++ b/roles/cfg_openwrt/templates/common/rc.local.j2
@@ -32,4 +32,10 @@ echo {{ override['value'] }} > {{ override['path'] }}
 {{ cmd }}
 {% endfor %}
 
+{% if snmp_devices|selectattr('snmp_profile', 'equalto', 'airos_6')|list|length >  0 %}
+# Change the option "procd_set_param stderr  1" to "0" in the file /etc/init.d/collectd
+# This is needed because airos_6 APs w/o stations resulted in a lot of local log spamming
+sed -i 's/\(procd_set_param stderr\)[[:space:]]*1/\1  0/' /etc/init.d/collectd
+{% endif %}
+
 exit 0


### PR DESCRIPTION
When collectd wants to get the Names of Stations via snmp connnected to a device running AirOS 6 that have none connected it reports a "NoSuchName" error to logd resulting in a lots of logspamming. At chris-core it was 60 per minute.

This Script will change the option "procd_set_param stderr  1" to "0" in the file /etc/init.d/collectd to deactivate logging of all errors. The monitoring will still work. I prefer not having logs over logspamming as the logfiles will get useless otherwise. It is still possible to change this option back to 1 until next boot to get a better insight when debugging collectd-issues.

This fixes #766