### PR TITLE
mela: 2g uplink, second core until install is fixed

### DIFF
--- a/locations/mela-2g.yml
+++ b/locations/mela-2g.yml
@@ -1,0 +1,180 @@
+---
+location: mela-2g
+location_nice: Melanchthonkirche, Melanchthonplatz, 13595 Berlin
+latitude: 52.521306576109
+longitude: 13.188832104206
+altitude: 60
+height: 24
+community: true
+
+hosts:
+  - hostname: mela-core-2g
+    role: corerouter
+    # model: "avm_fritzbox-4040"
+    model: "tplink_cpe210-v1"
+    # low flash until proper core router
+    low_flash: true
+    wireless_profile: mesh_only
+  # - hostname: mela-n2
+  #   role: ap
+  #   model: "tplink_cpe210-v1"
+  #   wireless_profile: freifunk_default
+  - hostname: mela-o2
+    role: ap
+    model: "tplink_cpe210-v1"
+    wireless_profile: mesh_only
+  - hostname: mela-s2
+    role: ap
+    model: "tplink_cpe210-v1"
+    wireless_profile: mesh_only
+  # - hostname: mela-w2
+  #   role: ap
+  #   model: "tplink_cpe210-v1"
+  #   wireless_profile: mesh_only
+  - hostname: mela-kanzel
+    role: ap
+    model: "tplink_cpe210-v1"
+
+snmp_devices:
+  - hostname: mela-switch-vorne
+    address: 10.31.244.131
+    snmp_profile: edgeswitch
+
+ipv6_prefix: "2001:bf7:780:800::/56"
+
+# got following prefixes:
+# Router:  10.31.244.128/25 (DHCP)
+#          2001:bf7:780:800::/56
+# --MGMT:  10.31.244.128/27
+# --MESH:  10.31.244.160/27
+# --DHCP:  10.31.244.192/26
+
+networks:
+  # MGMT
+  - vid: 42
+    role: mgmt
+    prefix: 10.31.244.128/27
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 1
+    assignments:
+      # Core
+      mela-core-2g: 1
+      # Switches
+      # mela-switch-hinten: 2
+      mela-switch-vorne: 3
+      # Ubiquiti APs + Stations
+      # mela-nw-5ghz: 4
+      # mela-oso-5ghz: 5
+      # mela-teufelsberg: 6
+      # OpenWRT APs (indoor, no Mesh)
+      mela-kanzel: 8
+      # OpenWRT 802.11s APs (Nahfeld)
+      # mela-n2: 9 - used as mela-core-2g
+      mela-o2: 10
+      mela-s2: 11
+      # mela-w2: 12  # defect, needs replacement
+      #mela-n5: 13  # unreachable, but wlan network
+      # mela-o5: 14
+      # mela-s5: 15
+      # mela-core-2g: 16
+
+  # DHCP
+  - vid: 40
+    role: dhcp
+    prefix: 10.31.244.192/26
+    ipv6_subprefix: 0
+    inbound_filtering: true
+    enforce_client_isolation: true
+    assignments:
+      mela-core-2g: 1
+
+  # MESH: 10.36.70.32/27
+  # PTMP / PTP Links
+  # - vid: 10
+  #   role: mesh
+  #   name: mesh_teufelsberg
+  #   prefix: 10.36.70.33/32
+  #   ipv6_subprefix: -10
+
+  # - vid: 11
+  #   role: mesh
+  #   name: mesh_nw
+  #   prefix: 10.36.70.34/32
+  #   ipv6_subprefix: -11
+
+  # - vid: 12
+  #   role: mesh
+  #   name: mesh_oso
+  #   prefix: 10.36.70.35/32
+  #   ipv6_subprefix: -12
+
+  # 802.11s Mesh
+  - vid: 20
+    role: mesh
+    name: mesh_11s_n2
+    prefix: 10.31.244.160/32
+    ipv6_subprefix: -20
+    # should be mela-n2
+    mesh_ap: mela-core-2g
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  - vid: 21
+    role: mesh
+    name: mesh_11s_o2
+    prefix: 10.31.244.161/32
+    ipv6_subprefix: -21
+    mesh_ap: mela-o2
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  - vid: 22
+    role: mesh
+    name: mesh_11s_s2
+    prefix: 10.31.244.162/32
+    ipv6_subprefix: -22
+    mesh_ap: mela-s2
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  - vid: 23
+    role: mesh
+    name: mesh_11s_w2
+    prefix: 10.31.244.163/32
+    ipv6_subprefix: -23
+    mesh_ap: mela-w2
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  # - vid: 24
+  #   role: mesh
+  #   name: mesh_11s_n5
+  #   prefix: 10.36.70.40/32
+  #   ipv6_subprefix: -24
+  #   mesh_ap: mela-n5
+  #   mesh_radio: 11a_standard
+  #   mesh_iface: mesh
+
+  # - vid: 25
+  #   role: mesh
+  #   name: mesh_11s_o5
+  #   prefix: 10.36.70.41/32
+  #   ipv6_subprefix: -25
+  #   # change this to mela-o2 once we have a new core-router
+  #   mesh_ap: mela-core
+  #   mesh_radio: 11a_standard
+  #   mesh_iface: mesh
+
+  # - vid: 26
+  #   role: mesh
+  #   name: mesh_11s_s5
+  #   prefix: 10.36.70.42/32
+  #   ipv6_subprefix: -26
+  #   mesh_ap: mela-s5
+  #   mesh_radio: 11a_standard
+  #   mesh_iface: mesh
+
+location__ssh_keys__to_merge:
+  - comment: torte
+    key: ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQBsKPa58c9LBwfupf3KlAsJHG+O9BNdTP0wB+0Ztl5Zl2/TeGfEEnOXxpf8gQq0qkG/pA40UP8jyejzliNfTZ+qOIfX+Jt1KXoBzNN7zBtYMzAAkrDgCqfIeLBAb/ArZyEanCOOz96bu4OfiktPJxbbRrlP/OV0XUZaLkSmIvxKFP5VHYyhvBxlwTrjSD8tdZJNFiZelHW/TRAT0uSfmgXBiXNThKVMNwwaCUp1R9QNbzFUhvnGyqrH8mQOYtHcZhPYAQOnUpJSYwBlyA4aIhAAgsPRZe1M5lEMn7ME6q6ERuQheGNmcNNqoxjrzIHbZjgTlprvdrzD7UPGNla7zcst torte@pluto

--- a/locations/mela.yml
+++ b/locations/mela.yml
@@ -87,7 +87,7 @@ networks:
       mela-core: 1
       # Switches
       mela-switch-hinten: 2
-      # mela-switch-vorn: 3
+      # mela-switch-vorne: 3
       # Ubiquiti APs + Stations
       mela-nw-5ghz: 4
       mela-oso-5ghz: 5

--- a/locations/torte-mela-2g.yml
+++ b/locations/torte-mela-2g.yml
@@ -1,0 +1,66 @@
+---
+location: torte-mela-2g
+location_nice: ""
+latitude: 52.52270515795004
+longitude: 13.186229014854849
+community: true
+
+hosts:
+  - hostname: torte-mela-2g
+    role: corerouter
+    model: "tplink_cpe210-v1"
+    # low flash until proper core router
+    low_flash: true
+    wireless_profile: mesh_only
+
+ipv6_prefix: "2001:bf7:780:700::/56"
+
+# got following prefixes:
+# Router:  10.31.243.224/27
+#          2001:bf7:780:700::/56
+# --MGMT:  10.31.243.224/29
+# --MESH:  10.31.243.232/29
+# --DHCP:  10.31.243.240/28
+
+networks:
+  # 802.11s Mesh 2.4 GHz
+  - vid: 20
+    role: mesh
+    name: mesh_mela
+    prefix: 10.31.243.232/32
+    ipv6_subprefix: -20
+    mesh_ap: torte-mela-2g
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
+
+  # MESH - LAN
+  - vid: 30
+    role: mesh
+    name: mesh_lan
+    prefix: 10.31.243.233/32
+    ipv6_subprefix: -30
+
+  # MGMT
+  - vid: 42
+    role: mgmt
+    prefix: 10.31.243.224/29
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 1
+    assignments:
+      # Core
+      torte-mela-2g: 1
+
+  # DHCP
+  - vid: 40
+    role: dhcp
+    prefix: 10.31.243.240/28
+    ipv6_subprefix: 0
+    inbound_filtering: true
+    enforce_client_isolation: true
+    assignments:
+      torte-mela-2g: 1
+
+location__ssh_keys__to_merge:
+  - comment: torte
+    key: ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQBsKPa58c9LBwfupf3KlAsJHG+O9BNdTP0wB+0Ztl5Zl2/TeGfEEnOXxpf8gQq0qkG/pA40UP8jyejzliNfTZ+qOIfX+Jt1KXoBzNN7zBtYMzAAkrDgCqfIeLBAb/ArZyEanCOOz96bu4OfiktPJxbbRrlP/OV0XUZaLkSmIvxKFP5VHYyhvBxlwTrjSD8tdZJNFiZelHW/TRAT0uSfmgXBiXNThKVMNwwaCUp1R9QNbzFUhvnGyqrH8mQOYtHcZhPYAQOnUpJSYwBlyA4aIhAAgsPRZe1M5lEMn7ME6q6ERuQheGNmcNNqoxjrzIHbZjgTlprvdrzD7UPGNla7zcst torte@pluto


### PR DESCRIPTION
This PR recovers the second part of the mela installation. The old core router is still broken and need to be replaced. Due to the fact that we have 2 switches the installation is now split in half.