### PR TITLE
zwingli: add packages to manage meshtastic node

### DIFF
--- a/.github/workflows/configrun.yml
+++ b/.github/workflows/configrun.yml
@@ -52,8 +52,15 @@ jobs:
           fi
           mkdir -p ./tmp/configs
 
+      - name: Create tar from configs folder
+        run: |
+          # create a tar containing the configs, as files with colons might be created which are rejected by upload-artifact
+          # upload-artifact rejects all files that might cause issues with file systems that do not support all characters
+          tar -cvf ./tmp/configs.tar ./tmp/configs/
+
       - name: Store build output
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ansibleconfigs
-          path: ./tmp/configs
+          path: |
+            ./tmp/configs.tar

--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -13,6 +13,9 @@ hosts:
     model: "linksys_e8450-ubi"
     wireless_profile: freifunk_default
     wifi_roaming: true
+    # USBIP packages to manage Meshtastic node (TLORA_V2_1_1P6) connected via USB
+    host__packages__to_merge:
+      - "kmod-usb-ohci usbip-server usbip-client"
 
   - hostname: zwingli-dome-1
     role: ap


### PR DESCRIPTION
We added a meshtastic node to zwingli and this adds the packages required to mange it remotely.
The artifact upload is broken due to files with colons, the workflow needs to be adjusted / fixed.