### PR TITLE
xdorf: replace core router

### DIFF
--- a/locations/xdorf.yml
+++ b/locations/xdorf.yml
@@ -11,7 +11,7 @@ hosts:
 
   - hostname: xdorf-core
     role: corerouter
-    model: "avm_fritzbox-7530"
+    model: "avm_fritzbox-4040"
     wireless_profile: freifunk_default
 
 snmp_devices:


### PR DESCRIPTION
This fixes freifunk-berlin/meta#44.

I switched the device, because I had a 4040 available. It is flashed and pwd is set, ready to be replaced as soon as I get contact to people from the location.

