### PR TITLE
newyorck: init location

### DIFF
--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -1,0 +1,197 @@
+---
+location: newyorck
+location_nice: Mariannenplatz 2A
+latitude: 52.50349
+longitude: 13.42385
+altitude: 39
+contact_nickname: NewYorck Internet AG
+contacts:
+  - newyorck@so36.net
+
+role: ap
+model: "siemens_ws-ap3610"
+wireless_profile: newyorck
+wifi_roaming: true
+
+hosts:
+
+  - hostname: newyorck-core
+    role: corerouter
+    model: "ubnt_edgerouter-x"
+    wireless_profile: disable
+
+  - hostname: newyorck-ap-1a
+  - hostname: newyorck-ap-1b
+  - hostname: newyorck-ap-1c
+  - hostname: newyorck-ap-1d
+  - hostname: newyorck-ap-1e
+  - hostname: newyorck-ap-1f
+  - hostname: newyorck-ap-1g
+  - hostname: newyorck-ap-2a
+  - hostname: newyorck-ap-2b
+  - hostname: newyorck-ap-2c
+  - hostname: newyorck-ap-2d
+  - hostname: newyorck-ap-3a
+  - hostname: newyorck-ap-3b
+
+snmp_devices:
+
+  # TL-SG2424
+  - hostname: newyorck-switch1
+    address: 10.31.155.226
+    snmp_profile: tplink
+
+  # TL-SG2424
+  - hostname: newyorck-switch2
+    address: 10.31.155.227
+    snmp_profile: tplink
+
+  # TL-SG3424P
+  - hostname: newyorck-switch3
+    address: 10.31.155.228
+    snmp_profile: tplink
+
+# PRDHCP: 10.31.247.0/25
+# --DHCP: 10.31.160.0/25
+# --MGMT: 10.31.155.224/27
+# --MESH: 10.31.155.192/29
+
+ipv6_prefix: "2001:bf7:830:a900::/56"
+
+networks:
+
+  - vid: 40
+    role: dhcp
+    prefix: 10.31.160.0/25
+    ipv6_subprefix: 40
+    inbound_filtering: true
+    enforce_client_isolation: true
+    assignments:
+      newyorck-core: 1
+
+  - vid: 41
+    name: prdhcp
+    role: dhcp
+    prefix: 10.31.247.0/25
+    ipv6_subprefix: 41
+    inbound_filtering: true
+    enforce_client_isolation: false
+    no_corerouter_dns_record: true
+    assignments:
+      newyorck-core: 1
+
+  - vid: 42
+    role: mgmt
+    prefix: 10.31.155.224/27
+    gateway: 1
+    dns: 1
+    ipv6_subprefix: 0
+    assignments:
+      newyorck-core: 1
+      newyorck-switch1: 2
+      newyorck-switch2: 3
+      newyorck-switch3: 4
+      newyorck-ap-1a: 5
+      newyorck-ap-1b: 6
+      newyorck-ap-1c: 7
+      newyorck-ap-1d: 8
+      newyorck-ap-1e: 9
+      newyorck-ap-1f: 10
+      newyorck-ap-1g: 11
+      newyorck-ap-2a: 12
+      newyorck-ap-2b: 13
+      newyorck-ap-2c: 14
+      newyorck-ap-2d: 15
+      newyorck-ap-3a: 16
+      newyorck-ap-3b: 17
+
+  - vid: 50
+    role: uplink
+
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.155.192/32
+    wireguard_port: 51820
+
+  - role: tunnel
+    ifname: ts_wg1
+    mtu: 1280
+    prefix: 10.31.155.193/32
+    wireguard_port: 51821
+
+location__channel_assignments_11a_standard__to_merge:
+  newyorck-ap-1a: 36-20
+  newyorck-ap-1b: 36-20
+  newyorck-ap-1c: 40-20
+  newyorck-ap-1d: 44-20
+  newyorck-ap-1e: 36-20
+  newyorck-ap-1f: 44-20
+  newyorck-ap-1g: 48-20
+  newyorck-ap-2a: 48-20
+  newyorck-ap-2b: 44-20
+  newyorck-ap-2c: 36-20
+  newyorck-ap-2d: 48-20
+  newyorck-ap-3a: 40-20
+  newyorck-ap-3b: 44-20
+
+location__channel_assignments_11g_standard__to_merge:
+  newyorck-ap-1a: 1-20
+  newyorck-ap-1b: 1-20
+  newyorck-ap-1c: 6-20
+  newyorck-ap-1d: 11-20
+  newyorck-ap-1e: 1-20
+  newyorck-ap-1f: 11-20
+  newyorck-ap-1g: 6-20
+  newyorck-ap-2a: 6-20
+  newyorck-ap-2b: 11-20
+  newyorck-ap-2c: 1-20
+  newyorck-ap-2d: 11-20
+  newyorck-ap-3a: 6-20
+  newyorck-ap-3b: 11-20
+
+location__wireless_profiles__to_merge:
+
+  - name: newyorck
+
+    devices:
+      - radio: 11a_standard
+        legacy_rates: false
+        country: DE
+      - radio: 11g_standard
+        legacy_rates: false
+        country: DE
+      - radio: 11a_mesh
+        legacy_rates: false
+        country: DE
+
+    ifaces:
+      - mode: ap
+        ssid: berlin.freifunk.net
+        encryption: none
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ff
+        owe_transition_ifname_hint: ffowe
+      - mode: ap
+        ssid: berlin.freifunk.net OWE
+        hidden: true
+        encryption: owe
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ffowe
+        owe_transition_ifname_hint: ff
+        ieee80211w: 1
+      - mode: ap
+        ssid: newyorck
+        encryption: psk2
+        key: 'file:/root/wifi_pass'
+        network: prdhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: prdhcp
+      - mode: mesh
+        mesh_id: Mesh-Freifunk-Berlin
+        radio: [11a_standard, 11g_standard, 11a_mesh]
+        mcast_rate: 12000
+        mesh_fwding: 0
+        ifname_hint: mesh


### PR DESCRIPTION
This is the proposal for a new Freifunk installation at the NewYorck site. If everything fits and is approved, please convert to a draft so that it is not accidentally merged before it has been deployed.