### PR TITLE
imagebuilder: OpenWrt snapshot now uses Zstd instead of xz-utils

### DIFF
--- a/group_vars/version_snapshot.yml
+++ b/group_vars/version_snapshot.yml
@@ -1,3 +1,5 @@
 ---
 # Don't use falter master, breaking changes are expected at the moment (7/2023)
 feed_version: 1.4.0-snapshot
+
+imagebuilder_filename: "openwrt-imagebuilder-{{ target | replace('/','-') }}.Linux-x86_64.tar.zst"


### PR DESCRIPTION
That means the tarball filename ends in `.zst` now (but not for 22.03 and 23.05)

https://github.com/openwrt/openwrt/commit/2496f436a837f4d56a13883497ab5d07fb01d0f7