### PR TITLE
emma: new corerouter, two 60ghz cubes, and radbahn tweaks

### DIFF
--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -9,7 +9,7 @@ community: true
 hosts:
   - hostname: emma-core
     role: corerouter
-    model: "linksys_e8450-ubi"
+    model: "avm_fritzbox-4040"
     wireless_profile: freifunk_default
 
 snmp_devices:

--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -29,6 +29,10 @@ snmp_devices:
     address: 10.31.11.5
     snmp_profile: edgeswitch
 
+  - hostname: emma-wsw-60ghz
+    address: 10.31.11.17
+    snmp_profile: mikrotik_60g
+
   - hostname: emma-ssw-uplink
     address: 10.31.11.18
     snmp_profile: mikrotik_60g
@@ -60,6 +64,10 @@ snmp_devices:
   - hostname: emma-sso-5ghz
     address: 10.31.11.25
     snmp_profile: airos_8
+
+  - hostname: emma-nnw-60ghz
+    address: 10.31.11.29
+    snmp_profile: mikrotik_60g
 
 airos_dfs_reset:
   - name: "emma-oso-5ghz"
@@ -123,7 +131,9 @@ networks:
       emma-switch-nw: 5
 
       # Router OS
+      emma-wsw-60ghz: 17    # Fenster 4
       emma-ssw-uplink: 18   # Fenster 2
+      emma-nnw-60ghz: 29    # Fenster 5
 
       # Airos 8, 5 GHz
       emma-oso-5ghz: 19     # Fenster 8, 20 MHz, center frequency 5580 MHz
@@ -195,6 +205,20 @@ networks:
     name: mesh_sso
     prefix: 10.31.11.40/32
     ipv6_subprefix: -17
+
+  - vid: 18
+    role: mesh
+    name: mesh_wsw_60ghz
+    prefix: 10.31.11.41/32
+    ipv6_subprefix: -18
+    ptp: true
+
+  - vid: 19
+    role: mesh
+    name: mesh_nnw_60ghz
+    prefix: 10.31.11.42/32
+    ipv6_subprefix: -19
+    ptp: true
 
 location__ssh_keys__to_merge:
   - comment: Vinet

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -2,8 +2,8 @@
 
 location: radbahn
 location_nice: Radbahn Testfeld
-latitude: 52.49928
-longitude: 13.42902
+latitude: 52.49917
+longitude: 13.42431
 contact_nickname: Stadtfunk gGmbH
 contacts:
   - noc@stadtfunk.net
@@ -18,11 +18,13 @@ hosts:
     role: ap
     model: zyxel_nwa55axe
     openwrt_version: snapshot
+    wireless_profile: radbahn
 
   - hostname: radbahn-w-nf
     role: ap
     model: zyxel_nwa55axe
     openwrt_version: snapshot
+    wireless_profile: radbahn
 
 snmp_devices:
 
@@ -101,3 +103,54 @@ networks:
       radbahn-emma: 2
       radbahn-o-nf: 3
       radbahn-w-nf: 4
+
+location__channel_assignments_11a_standard__to_merge:
+  radbahn-o-nf: 36-40
+  radbahn-w-nf: 44-40
+
+location__channel_assignments_11b_standard__to_merge:
+  radbahn-o-nf: 9-20
+  radbahn-w-nf: 13-20
+
+location__wireless_profiles__to_merge:
+  - name: radbahn
+    devices:
+      - radio: 11a_standard
+        legacy_rates: false
+        country: DE
+      - radio: 11g_standard
+        legacy_rates: false
+        country: DE
+      - radio: 11a_mesh
+        legacy_rates: false
+        country: DE
+
+    ifaces:
+      - mode: ap
+        ssid: berlin.freifunk.net
+        encryption: none
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ff
+
+      - mode: ap
+        ssid: radbahn.freifunk.berlin
+        encryption: none
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ffcust
+
+      - mode: ap
+        ssid: berlin.freifunk.net Encrypted
+        encryption: owe
+        network: dhcp
+        radio: [11a_standard, 11g_standard]
+        ifname_hint: ffowe
+        ieee80211w: 1
+
+      - mode: mesh
+        mesh_id: Mesh-Freifunk-Berlin
+        radio: [11a_standard, 11g_standard, 11a_mesh]
+        mcast_rate: 12000
+        mesh_fwding: 0
+        ifname_hint: mesh

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -43,7 +43,7 @@ networks:
   - vid: 10
     name: mesh_emma
     role: mesh
-    prefix: 10.230.251.65/32
+    prefix: 10.31.251.65/32
     ipv6_subprefix: -10
     ptp: true
 


### PR DESCRIPTION
:candle: :pray: 

> The OKOD - OpenWrt Kiss of Death - strikes again.
>
> We don’t know why, we don’t know when;
> but it’s only a matter of time,
> before OKOD strikes another poor RT3200 again.
> All was once well, but that was only then;
> once it was five, but five became ten.
> So we ain’t got no zen,
> knowing OKOD will strike for sure anytime again.
> WiFi 6, tricks and nice cake-mix, but too many bricks;
> we therefore place all our hope in [daniel](https://forum.openwrt.org/u/daniel) and [his promised fix](https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/4002).
>
> *-- Lynx https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/4085*

---

- Bring in new Fritzbox 4040 as corerouter. The Belkin RT3200 self-bricked and needs to be recovered with serial or JTAG...
- Connect new location radbahn using a 60 GHz Mikrotik Cube -- emma-wsw-60ghz.olsr
- Connect another new location using same 60 GHz model -- emma-nnw-60ghz.olsr
- Optimize radbahn wifi channels and map location
- Add additional site-specific SSID "radbahn.freifunk.berlin" - they specifically asked for an SSID that advertises the project which I think is a very cool way to socialize with the neighbourhood.