### PR TITLE
newyorck: simplify wireless

### DIFF
--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -11,7 +11,6 @@ contacts:
 role: ap
 model: "siemens_ws-ap3610"
 wireless_profile: newyorck
-wifi_roaming: true
 
 hosts:
 
@@ -161,9 +160,6 @@ location__wireless_profiles__to_merge:
       - radio: 11g_standard
         legacy_rates: false
         country: DE
-      - radio: 11a_mesh
-        legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap
@@ -172,16 +168,15 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ff
-        owe_transition_ifname_hint: ffowe
+
       - mode: ap
-        ssid: berlin.freifunk.net OWE
-        hidden: true
+        ssid: berlin.freifunk.net Encrypted
         encryption: owe
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        owe_transition_ifname_hint: ff
         ieee80211w: 1
+
       - mode: ap
         ssid: newyorck
         encryption: psk2
@@ -189,9 +184,3 @@ location__wireless_profiles__to_merge:
         network: prdhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: prdhcp
-      - mode: mesh
-        mesh_id: Mesh-Freifunk-Berlin
-        radio: [11a_standard, 11g_standard, 11a_mesh]
-        mcast_rate: 12000
-        mesh_fwding: 0
-        ifname_hint: mesh


### PR DESCRIPTION
There were reports of different kind of problems for clients to connect. I now simplified the wireless setup by:
- removing the roaming feature, because this seems to be the problem that made some aps unresponsive (issue for that coming soon)
- use same freifunk wireless profile as the default, so that owe transition should not make problems
- remove mesh, as it is not needed for the indoor antennas

This new version is running for about 5 days now and seems to have fixed the problems.