### PR TITLE
network: allow other ports in addition to eth0

### DIFF
--- a/locations/pktpls.yml
+++ b/locations/pktpls.yml
@@ -54,9 +54,14 @@ networks:
     assignments:
       pktpls-core: 1
 
+  # - vid: 50
+  #   role: uplink
+  #   untagged: false
+
   - vid: 50
+    ifname: eth1
     role: uplink
-    untagged: false
+    untagged: true
 
   - role: tunnel
     ifname: ts_wg0

--- a/roles/cfg_openwrt/templates/common/config/dsa.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/dsa.network.inc
@@ -2,7 +2,7 @@ config device
 	option type 'bridge'
 	option name 'switch0'
 
-{% for network in networks | selectattr('vid', 'defined') %}
+{% for network in networks | selectattr('vid', 'defined') | selectattr('ifname', 'undefined') %}
   {% set portmapping = [] %}
   {% for port in dsa_ports %}
     {% set tagged = not network.get('untagged') %}

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -20,10 +20,16 @@ config interface 'loopback'
 
 {% for network in networks | selectattr('vid', 'defined') %}
   {% set name = network['name'] if 'name' in network else network['role'] %}
-  {% if (dsa_ports is defined) or (switch_ports|default(0) > 0) %}
-    {% set port = ('switch0' if dsa_ports is defined else int_port) + '.' + network['vid']|string %}
+  {% set vid = network['vid']|string %}
+  {% set untagged = network.get('untagged') %}
+  {% if 'ifname' in network %}
+    {% set port = network['ifname'] + ('' if untagged else '.' + vid) %}
+  {% elif dsa_ports is defined %}
+    {% set port = 'switch0' + '.' + vid %}
+  {% elif (switch_ports|default(0) > 0) %}
+    {% set port = int_port + '.' + vid %}
   {% else %}
-    {% set port = ((int_port) + '.' + network['vid']|string if not network.get('untagged') else (int_port)) %}
+    {% set port = int_port + ('' if untagged else '.' + vid) %}
   {% endif %}
   {% set bridge_name = 'br-' + name %}
   {% set bridge_needed = name in wifi_networks or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and 'tunnel_wan_ip' in network) or (role == 'corerouter' and network['role'] == 'uplink') %}

--- a/roles/cfg_openwrt/templates/common/config/swconfig.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/swconfig.network.inc
@@ -6,7 +6,7 @@ config switch
 {% else %}
 	option enable_vlan '1'
 
-  {% for network in networks | selectattr('vid', 'defined') %}
+  {% for network in networks | selectattr('vid', 'defined') | selectattr('ifname', 'undefined') %}
     {% set portmapping = [] %}
     {% for port in range(switch_ports)|list|difference(switch_ignore_ports|default([])) %}
       {% set tagged = not network.get('untagged') or port == switch_int_port %}

--- a/vm.sh
+++ b/vm.sh
@@ -129,6 +129,11 @@ cat << EOF > "$vmdir/vmconfig.json"
       "host_dev_name": "vmeth0",
       "iface_id": "eth0",
       "guest_mac": "02:fc:00:00:00:06"
+    },
+    {
+      "host_dev_name": "vmeth1",
+      "iface_id": "eth1",
+      "guest_mac": "02:fc:01:00:00:06"
     }
   ]
 }
@@ -152,8 +157,12 @@ ip link set up vmeth0.42
 ip addr add $cnip dev vmeth0.42
 ip route add $mgmtnet dev vmeth0.42
 
+ip tuntap add dev vmeth1 mode tap
+ip link set up vmeth1
+
 brctl addbr wan
 brctl addif wan vmeth0.50
+brctl addif wan vmeth1
 brctl addif wan tap0
 ip link set up wan
 ip route del \`ip r | grep '24 dev tap0'\`


### PR DESCRIPTION
The network templates cover three possible port configs:

- Switch chip with DSA driver: `switch0`
- Switch chip with swconfig driver: `eth0` (usually)
- No switch chip: `eth0` (usually)

This patch adds the possibility of a fourth port config,
where an additional physical port can be used for individual VLANs.
Examples include 4G USB sticks, devices without a switch chip but with
multiple ports, etc.

The `vm.sh` script now offers uplink on both `eth0.50` and `eth1`.

We also simplify the whole `port` logic a little bit.

Bonus: this will also make it easier to refactor how we define gateways locations.