### PR TITLE
karanfil: init location

### DIFF
--- a/locations/karanfil.yml
+++ b/locations/karanfil.yml
@@ -1,0 +1,78 @@
+---
+
+location: karanfil
+location_nice: Cafe Karanfil
+latitude: 52.47996
+longitude: 13.42292
+contact_nickname: Stadtfunk gGmbH
+contacts:
+  - noc@stadtfunk.net
+
+hosts:
+
+  - hostname: karanfil-core
+    role: corerouter
+    model: avm_fritzbox-4040
+    wireless_profile: freifunk_default
+
+# 10.31.245.128/25
+# 10.31.245.128/28 - mgmt     - vlan 42
+# 10.31.245.144/28 - mesh
+# 10.31.245.160/27 - privdhcp - vlan 41
+# 10.31.245.192/26 - dhcp     - vlan 40
+ipv6_prefix: 2001:bf7:820:2b00::/56
+
+networks:
+
+  - vid: 20
+    name: mesh_core
+    role: mesh
+    prefix: 10.31.245.144/32
+    ipv6_subprefix: -1
+
+  - vid: 40
+    name: dhcp
+    role: dhcp
+    prefix: 10.31.245.192/26
+    ipv6_subprefix: -2
+    inbound_filtering: true
+    enforce_client_isolation: true
+    assignments:
+      karanfil-core: 1
+
+  - vid: 41
+    name: prdhcp
+    role: dhcp
+    prefix: 10.31.245.160/27
+    ipv6_subprefix: -3
+    inbound_filtering: true
+    enforce_client_isolation: false
+    no_corerouter_dns_record: true
+    assignments:
+      karanfil-core: 1
+
+  - vid: 42
+    name: mgmt
+    role: mgmt
+    prefix: 10.31.245.128/28
+    ipv6_subprefix: 1
+    gateway: 1
+    dns: 1
+    assignments:
+      karanfil-core: 1
+
+  - vid: 50
+    role: uplink
+    untagged: true
+
+  - role: tunnel
+    ifname: ts_wg0
+    mtu: 1280
+    prefix: 10.31.245.145/32
+    wireguard_port: 51820
+
+  - role: tunnel
+    ifname: ts_wg1
+    mtu: 1280
+    prefix: 10.31.245.146/32
+    wireguard_port: 51821


### PR DESCRIPTION
https://hopglass.berlin.freifunk.net/#!v:m;n:karanfil-core.olsr