### PR TITLE
radbahn: downgrade APs to 23.05, debugging mt76

### DIFF
--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -17,13 +17,11 @@ hosts:
   - hostname: radbahn-o-nf
     role: ap
     model: zyxel_nwa55axe
-    openwrt_version: snapshot
     wireless_profile: radbahn
 
   - hostname: radbahn-w-nf
     role: ap
     model: zyxel_nwa55axe
-    openwrt_version: snapshot
     wireless_profile: radbahn
 
 snmp_devices:


### PR DESCRIPTION
We're affected by "Message timeout while waiting for mcu response"

See https://github.com/openwrt/mt76/issues/690