### PR TITLE
magda: reduce lqm to 0.2 to liese-11-sw-core

### DIFF
--- a/locations/magda.yml
+++ b/locations/magda.yml
@@ -68,7 +68,7 @@ networks:
     ipv6_subprefix: -2
     # Adjust mesh metric to liese-11-sw-core to prevent using it
     # as a gateway during heavy rain
-    mesh_metric_lqm: ['10.31.205.49 0.5']
+    mesh_metric_lqm: ['10.31.205.49 0.2']
 
   - vid: 42
     role: mgmt


### PR DESCRIPTION
0.5 is not enough to prevent liese-11-sw-core to become a gateway.

Fixes: 87b2c9fc70de ("magda: liese-11-sw-core lqm")