### PR TITLE
workflows: add ip prefix duplicate check / fix duplicates

### DIFF
--- a/.github/checks/check-ip-prefix-duplicates.sh
+++ b/.github/checks/check-ip-prefix-duplicates.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Change to the locations directory
+cd locations || exit 1
+
+# Check for IPv4 duplicates
+ipv4_duplicates=$(sed -nE 's/^\s*prefix:\s*["'\''"]?([^"'\''\s#]+)["'\''"]?/\1/p' ./*.yml | sort | uniq -cd)
+
+# Check for IPv6 duplicates
+ipv6_duplicates=$(sed -nE 's/^\s*ipv6_prefix:\s*["'\''"]?([0-9a-fA-F:]+\/[0-9]+)["'\''"]?/\1/p' ./*.yml | sort | uniq -cd)
+
+
+if [ -n "$ipv4_duplicates" ] || [ -n "$ipv6_duplicates" ]; then
+  if [ -n "$ipv4_duplicates" ]; then
+    echo "Duplicate IPv4 prefixes found:"
+    echo "$ipv4_duplicates"
+  fi
+  if [ -n "$ipv6_duplicates" ]; then
+    echo "Duplicate IPv6 prefixes found:"
+    echo "$ipv6_duplicates"
+  fi
+  exit 1
+else
+  echo "No duplicate prefixes found."
+fi

--- a/.github/workflows/check-ip-prefix-duplicates.yml
+++ b/.github/workflows/check-ip-prefix-duplicates.yml
@@ -1,0 +1,17 @@
+---
+name: Check for duplicate IP prefixes
+
+on: [push, pull_request]  # yamllint disable-line rule:truthy
+
+jobs:
+  check-ip-prefix-duplicates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run IP prefix duplicate check
+        run: |
+          ./.github/checks/check-ip-prefix-duplicates.sh

--- a/locations/habersaath.yml
+++ b/locations/habersaath.yml
@@ -98,7 +98,7 @@ networks:
   - vid: 20
     role: mesh
     name: w_nf_5ghz
-    prefix: 10.31.147.225/32
+    prefix: 10.31.147.224/32
     ipv6_subprefix: -1
     mesh_ap: habersaath-w-nf-5ghz
     mesh_radio: 11a_standard
@@ -154,13 +154,13 @@ networks:
   - role: tunnel
     ifname: ts_wg0
     mtu: 1280
-    prefix: 10.31.147.224/32
+    prefix: 10.31.147.225/32
     wireguard_port: 51820
 
   - role: tunnel
     ifname: ts_wg1
     mtu: 1280
-    prefix: 10.31.147.225/32
+    prefix: 10.31.147.226/32
     wireguard_port: 51821
 
 location__channel_assignments_11a_standard__to_merge:

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -45,7 +45,7 @@ networks:
   - vid: 20
     role: mesh
     name: mesh_5g
-    prefix: 10.31.215.33/32
+    prefix: 10.31.215.32/32
     ipv6_subprefix: -20
     mesh_ap: noki-core
     mesh_radio: 11a_standard
@@ -55,7 +55,7 @@ networks:
   - vid: 21
     role: mesh
     name: mesh_2g
-    prefix: 10.31.215.34/32
+    prefix: 10.31.215.33/32
     ipv6_subprefix: -21
     # make mesh_metric(s) for 2GHz worse than 5GHz
     mesh_metric: 1024
@@ -68,7 +68,7 @@ networks:
   - vid: 30
     role: mesh
     name: mesh_lan
-    prefix: 10.31.215.35/32
+    prefix: 10.31.215.34/32
     ipv6_subprefix: -30
 
   # DHCP with filtering and isolation


### PR DESCRIPTION
This ensures that we do not have duplicate IP prefixes any more:

![image](https://github.com/user-attachments/assets/9bed9867-c053-4ec3-862b-cc890de0c915)

closes https://github.com/freifunk-berlin/bbb-configs/issues/901
