### PR TITLE
weidenbaum: make weidenbaum-r0 an AP

### DIFF
--- a/locations/weidenbaum.yml
+++ b/locations/weidenbaum.yml
@@ -1,17 +1,23 @@
 ---
 location: weidenbaum
 location_nice: Kleingartenkolonie Weidenbaum, Straße 70 Nr. 8+10, 13627 Berlin
-latitude: 52.542224269476314
-longitude: 13.305274844169617
+latitude: 52.54227473545742
+longitude: 13.305438420309441
 altitude: 27
 height: 6
 community: true
 
 hosts:
+
   - hostname: weidenbaum-core
     role: corerouter
     model: "avm_fritzbox-4040"
     wireless_profile: freifunk_default
+
+  - hostname: weidenbaum-r0
+    role: ap
+    model: "ubnt_unifiac-mesh"
+    openwrt_version: 23.05-SNAPSHOT
 
 snmp_devices:
 
@@ -37,44 +43,51 @@ networks:
     ipv6_subprefix: -10
 
   # 802.11s Links
-  # MESH - 5 GHz 802.11s
+  # MESH - 5 GHz 802.11s - core
   - vid: 20
     role: mesh
     name: mesh_5g
     prefix: 10.31.204.147/32
     ipv6_subprefix: -20
-    # make mesh_metric(s) for 5GHz worse than LAN
-    mesh_metric: 768
-    mesh_metric_lqm: ['default 0.75']
     mesh_ap: weidenbaum-core
     mesh_radio: 11a_standard
     mesh_iface: mesh
 
-  # MESH - 2.4 GHz 802.11s
+  # MESH - 2.4 GHz 802.11s - core
   - vid: 21
     role: mesh
     name: mesh_2g
     prefix: 10.31.204.148/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than LAN and 2GHz
+    # make mesh_metric(s) for 2GHz worse than 5GHz
     mesh_metric: 1024
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: weidenbaum-core
     mesh_radio: 11g_standard
     mesh_iface: mesh
 
-  # MESH - LAN
-  # Ubiquiti UniFi AC Mesh - weidenbaum-r0
-  # This is currently Falter but should be converted into
-  # a normal AP at some point. We had UniFi AC Mesh that
-  # got bricked when flashing and we did not want to risk
-  # doing so.
-  - vid: 30
+  # MESH - 5 GHz 802.11s - r0
+  - vid: 22
     role: mesh
-    name: mesh_lan
-    untagged: true
-    prefix: 10.31.204.151/32
-    ipv6_subprefix: -30
+    name: mesh_5g_r0
+    prefix: 10.31.204.149/32
+    ipv6_subprefix: -22
+    mesh_ap: weidenbaum-r0
+    mesh_radio: 11a_standard
+    mesh_iface: mesh
+
+  # MESH - 2.4 GHz 802.11s -r0
+  - vid: 23
+    role: mesh
+    name: mesh_2g_r0
+    prefix: 10.31.204.150/32
+    ipv6_subprefix: -23
+    # make mesh_metric(s) for 2GHz worse than 5GHz
+    mesh_metric: 1024
+    mesh_metric_lqm: ['default 0.5']
+    mesh_ap: weidenbaum-r0
+    mesh_radio: 11g_standard
+    mesh_iface: mesh
 
   # DHCP
   - vid: 40
@@ -96,3 +109,4 @@ networks:
     assignments:
       weidenbaum-core: 1       # .129
       weidenbaum-bht: 2        # .130
+      weidenbaum-r0: 3         # .131


### PR DESCRIPTION
not flashed yet. this requires a two step flash process via a minimalistic image.