### PR TITLE
model: ubnt unifiac mesh: fix 2.4 ghz path

### DIFF
--- a/group_vars/model_ubnt_unifiac_mesh.yml
+++ b/group_vars/model_ubnt_unifiac_mesh.yml
@@ -18,5 +18,5 @@ wireless_devices:
   - name: 11g_standard
     band: 2g
     htmode_prefix: HT
-    path: platform/qca956x_wmac
+    path: platform/ahb/18100000.wmac
     ifname_hint: wlan2


### PR DESCRIPTION
Cherry-picking this fix from #889