### PR TITLE
Collectd: Adding ping monitoring for IPv6 

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -17,7 +17,9 @@ ntp_servers:
   - 3.openwrt.pool.ntp.org
 
 collectd_host: monitor.berlin.freifunk.net
-collectd_ping_host: 1.1.1.1
+collectd_ping_hosts:
+  - 1.1.1.1
+  - 2606:4700:4700::1111
 
 # Preserve following files (allow list)
 sysupgrade_preserve_custom_files:

--- a/roles/cfg_openwrt/templates/common/collectd/conf.d/basic.conf.j2
+++ b/roles/cfg_openwrt/templates/common/collectd/conf.d/basic.conf.j2
@@ -3,11 +3,13 @@ LoadPlugin uptime
 LoadPlugin interface
 
 LoadPlugin ping
+{% for host in collectd_ping_hosts %}
 <Plugin ping>
 	TTL 127
 	Interval 10
-	Host "{{ collectd_ping_host }}"
+	Host "{{ host }}"
 </Plugin>
+{% endfor %}
 
 LoadPlugin memory
 <Plugin memory>


### PR DESCRIPTION
Right now we only monitor IPv4 pings, but I think IPv6 would interesting as well especially because we use different routing protocols for them. The IPv6 address is from Cloudflare as well to make them comparable.