### PR TITLE
version: switch snapshot back to snapshot feed

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -18,10 +18,11 @@ all__packages__to_merge:
   - ip6tables                  # Its not pulled in by default anymore bc fw4
   - iperf3
   - iwinfo
+  - ip
   - kmod-nft-bridge
   - mtr
   - nftables
-  - tcpdump
+  - tcpdump-mini
   - vnstat
   - -ppp
   - -ppp-mod-pppoe

--- a/group_vars/version_snapshot.yml
+++ b/group_vars/version_snapshot.yml
@@ -1,5 +1,4 @@
 ---
-# Don't use falter master, breaking changes are expected at the moment (7/2023)
-feed_version: 1.4.0-snapshot
+feed_version: snapshot
 
 imagebuilder_filename: "openwrt-imagebuilder-{{ target | replace('/','-') }}.Linux-x86_64.tar.zst"

--- a/locations/pktpls.yml
+++ b/locations/pktpls.yml
@@ -11,13 +11,12 @@ hosts:
   - hostname: pktpls-core
     role: corerouter
     model: "x86-64"
+    openwrt_version: snapshot
 
-# feed: "src/gz openwrt_falter file:///home/user/w/ff/falter-packages/out/openwrt-23.05/x86_64/falter"
+# feed: "src/gz openwrt_falter file:///home/user/w/ff/falter-packages/out/main/x86_64/falter"
 # imagebuilder_disable_signature_check: true
 
 location__packages__to_merge:
-  - -luci-mod-falter
-  - -falter-common
   - openssh-sftp-server
 
 # 10.31.174.128/26 - pktpls+bbb@systemli.org

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -42,7 +42,7 @@
 
 - name: "Add debugging-packages on core-routers"
   set_fact:
-    packages: "{{ packages + ['mosh-server', 'tmux', 'ip'] }}"
+    packages: "{{ packages + ['mosh-server', 'tmux'] }}"
   when:
     - not (low_flash | default(false))
     - role == 'corerouter'


### PR DESCRIPTION
The falter-packages main branch has stabilized, it's now again safe to pull in falter-common.