### PR TITLE
packages: no debug packages with low_mem

### DIFF
--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -44,8 +44,9 @@
   set_fact:
     packages: "{{ packages + ['mosh-server', 'tmux'] }}"
   when:
-    - not (low_flash | default(false))
     - role == 'corerouter'
+    - not (low_mem | default(false))
+    - not (low_flash | default(false))
 
 - name: "Remove or replace packages on low mem and low flash"
   set_fact:

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -56,6 +56,8 @@
     - -ethtool
     - -iperf3
     - -iwinfo
+    - -libiwinfo-lua
+    - -collectd-mod-iwinfo
     - -kmod-ipt-core
     - -kmod-ipt-offload
     - -kmod-nf-ipt


### PR DESCRIPTION
these packages add to the size of the image that will be uploaded to /tmp/ and should therefore be removed for low_mem.