### PR TITLE
model: Nanostation Loco XM (1 port) support for both 2.4 and 5 GHz

### DIFF
--- a/group_vars/model_ubnt_bullet_m2_ar7241.yml
+++ b/group_vars/model_ubnt_bullet_m2_ar7241.yml
@@ -2,7 +2,7 @@
 override_target: "ubnt_bullet-m-ar7241"
 target: ath79/tiny
 brand_nice: Ubiquiti
-model_nice: Bullet M
+model_nice: Bullet M2
 version_nice: XM
 
 int_port: eth0

--- a/group_vars/model_ubnt_bullet_m5_ar7241.yml
+++ b/group_vars/model_ubnt_bullet_m5_ar7241.yml
@@ -1,0 +1,18 @@
+---
+override_target: "ubnt_bullet-m-ar7241"
+target: ath79/tiny
+brand_nice: Ubiquiti
+model_nice: Bullet M5
+version_nice: XM
+
+int_port: eth0
+
+low_mem: true
+
+wireless_devices:
+  - name: 11a_standard
+    band: 5g
+    htmode_prefix: HT
+    path: pci0000:00/0000:00:00.0
+    ifname_hint: wlan5
+    antenna_gain: 13

--- a/locations/jup.yml
+++ b/locations/jup.yml
@@ -28,7 +28,7 @@ hosts:
 
   - hostname: jup-bullet-ap4
     role: ap
-    model: "ubnt_bullet-m-ar7241"
+    model: "ubnt_bullet-m2-ar7241"
 
   - hostname: jup-m5-ap5
     role: ap

--- a/locations/ska95.yml
+++ b/locations/ska95.yml
@@ -38,7 +38,7 @@ hosts:
 
   - hostname: ska95-cortile
     role: ap
-    model: ubnt_bullet-m-ar7241
+    model: ubnt_bullet-m2-ar7241
 
 snmp_devices:
   - hostname: ska95-emma


### PR DESCRIPTION
We have a bunch of Nanostation M5/M2 Loco XM 1 with only 1 ethernet port. The installation section for these devices states that they will be bricked when installing the latest Nanostation firmware and instead the Bullet M firmware should be used (https://openwrt.org/toh/ubiquiti/nanostationm5#installation). This PR creates a model file for a 2.4 GHz and 5 GHz version that can be used and works with the devices we have so they can be deployed in the field.