### PR TITLE
all: mt76 driver debugging

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -1,6 +1,7 @@
 ---
 zonename: 'Europe/Berlin'
 timezone: 'CET-1CEST,M3.5.0,M10.5.0/3'
+log_size: 64
 
 # TODO: find a second good DNS upstream in Berlin
 dns_servers:

--- a/locations/huette.yml
+++ b/locations/huette.yml
@@ -16,8 +16,12 @@ hosts:
     role: corerouter
     model: "zyxel_nwa55axe"
     wireless_profile: freifunk_default
+    openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
     host__rclocal__to_merge:
-      - 'cat /etc/crontabs/root | grep reboot 2>/dev/null || echo "15 * * * * reboot" >> /etc/crontabs/root && /etc/init.d/cron restart'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
+    ssl__packages__to_merge: []
 
 ipv6_prefix: '2001:bf7:830:2600::/56'
 
@@ -39,17 +43,17 @@ networks:
     mesh_iface: mesh
 
   # MESH - 2.4 GHz 802.11s
-  - vid: 21
-    role: mesh
-    name: mesh_11s_2ghz
-    prefix: 10.31.114.2/32
-    ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
-    mesh_metric_lqm: ['default 0.8']
-    mesh_ap: huette-core
-    mesh_radio: 11g_standard
-    mesh_iface: mesh
+  # - vid: 21
+  #   role: mesh
+  #   name: mesh_11s_2ghz
+  #   prefix: 10.31.114.2/32
+  #   ipv6_subprefix: -21
+  #   # make mesh_metric(s) for 2GHz worse than 5GHz
+  #   mesh_metric: 1024
+  #   mesh_metric_lqm: ['default 0.8']
+  #   mesh_ap: huette-core
+  #   mesh_radio: 11g_standard
+  #   mesh_iface: mesh
 
   - vid: 40
     role: dhcp

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -13,16 +13,16 @@ contacts:
 # - 10.31.255.192/27    dhcp
 # - 10.31.255.224/28    prdhcp
 # - 10.31.255.240/29    mesh
-#   - 10.31.255.240/32  mesh_emma
-#   - 10.31.255.241/32  ts_wg1
+#   - 10.31.255.240/32  mesh_lan
+#   - 10.31.255.241/32  ts_wg0
 # - 10.31.255.248/29    mgmt
 ipv6_prefix: 2001:bf7:820:2c00::/56
 
 hosts:
 
-  # Thinkcentre M720q, i5-8500T, ??GB RAM, ???GB NVMe
-  # Intel I219 V7 - eth0
-  # ConnectX-4 LX CX4121B - eth1, eth2
+  # Thinkcentre M720q, i5-8500T, 16GB RAM, 1TB NVMe
+  # eth0      - Intel I219 V7
+  # eth1 eth2 - ConnectX-4 Lx CX4121B
   - hostname: hway-core
     role: corerouter
     model: x86-64
@@ -37,13 +37,14 @@ hosts:
 
   - hostname: hway-ap1
     role: ap
+    wireless_profile: hway
     model: zyxel_nwa50ax
-    wireless_profile: hway
-
-  - hostname: hway-ap2
-    role: ap
-    model: mikrotik_wap-ac
-    wireless_profile: hway
+    openwrt_version: snapshot
+    log_size: 1024
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    host__rclocal__to_merge:
+      - "echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm"
+    ssl__packages__to_merge: []
 
 snmp_devices:
 
@@ -55,7 +56,7 @@ networks:
 
   - vid: 10
     role: mesh
-    name: mesh_emma
+    name: mesh_lan
     prefix: 10.31.255.240/32
     ipv6_subprefix: -10
 
@@ -89,7 +90,6 @@ networks:
       hway-switch: 2     # .255.250
       hway-kiehlufer: 3  # .255.251
       hway-ap1: 4        # .255.252
-      hway-ap2: 5        # .255.253
 
   - vid: 50
     ifname: eth1
@@ -104,11 +104,9 @@ networks:
 
 location__channel_assignments_11a_standard__to_merge:
   hway-ap1: 36-40
-  hway-ap2: 44-40
 
 location__channel_assignments_11b_standard__to_merge:
   hway-ap1: 13-20
-  hway-ap2: 9-20
 
 location__wireless_profiles__to_merge:
   - name: hway

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -30,11 +30,21 @@ hosts:
     role: corerouter
     model: "cudy_x6-v1"
     wireless_profile: freifunk_default
+    openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
+    ssl__packages__to_merge: []
 
   - hostname: kiehlufer-huette
     role: ap
     model: "zyxel_nwa55axe"
     wireless_profile: kiehlufer5g
+    openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
+    host__rclocal__to_merge:
+      - "echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm"
+    ssl__packages__to_merge: []
 
   - hostname: kiehlufer-nf-wbp1
     role: ap

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -28,7 +28,7 @@ hosts:
 
   - hostname: kiehlufer-core
     role: corerouter
-    model: "linksys_e8450-ubi"
+    model: "cudy_x6-v1"
     wireless_profile: freifunk_default
 
   - hostname: kiehlufer-huette

--- a/locations/kub.yml
+++ b/locations/kub.yml
@@ -19,7 +19,13 @@ hosts:
   - hostname: kub-ap1
     role: ap
     model: "cudy_x6-v1"
+    openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
     host__rclocal__to_merge:
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
+      - ''
       - '#'
       - '# This script adjusts the configuration of vlans. This is especially'
       - '# useful with uswflex and custom port configs'
@@ -67,6 +73,7 @@ hosts:
       - 'uci commit network'
       - 'sync'
       - 'reload_config'
+    ssl__packages__to_merge: []
 
 snmp_devices:
   - hostname: kub-simeon

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -18,15 +18,25 @@ hosts:
     role: ap
     model: zyxel_nwa55axe
     wireless_profile: radbahn
+    openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
     host__rclocal__to_merge:
-      - 'cat /etc/crontabs/root | grep reboot 2>/dev/null || echo "15 * * * * reboot" >> /etc/crontabs/root && /etc/init.d/cron restart'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
+    ssl__packages__to_merge: []
 
   - hostname: radbahn-w-nf
     role: ap
     model: zyxel_nwa55axe
     wireless_profile: radbahn
+    openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
     host__rclocal__to_merge:
-      - 'cat /etc/crontabs/root | grep reboot 2>/dev/null || echo "45 * * * * reboot" >> /etc/crontabs/root && /etc/init.d/cron restart'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
+    ssl__packages__to_merge: []
 
 snmp_devices:
 

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -20,6 +20,12 @@ hosts:
     wireless_profile: freifunk_default
     dhcp_no_ping: false
     openwrt_version: snapshot
+    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
+    log_size: 1024
+    host__rclocal__to_merge:
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
+      - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
+    ssl__packages__to_merge: []
 
 # 10.248.13.0/24
 # 10.248.13.0/29 - mgmt

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -4,9 +4,9 @@ location_nice: Suedblock
 latitude: 52.498599118
 longitude: 13.416844010
 altitude: 33
-contact_nickname: '365ff'
+contact_nickname: Stadtfunk gGmbH
 contacts:
-  - '365ff [ät] systemli [dot] org'
+  - noc@stadtfunk.net
 
 location__ssh_keys__to_merge:
   - comment: narfpeng
@@ -19,14 +19,19 @@ hosts:
     model: "cudy_x6-v1"
     wireless_profile: freifunk_default
     dhcp_no_ping: false
+    openwrt_version: snapshot
 
+# 10.248.13.0/24
+# 10.248.13.0/29 - mgmt
+# 10.248.13.8/29 - mesh
+# 10.248.13.128/25 - dhcp
 ipv6_prefix: "2001:bf7:830:b100::/56"
 
 networks:
 
   - vid: 42
     role: mgmt
-    prefix: 10.31.15.196/32
+    prefix: 10.248.13.0/29
     gateway: 1
     dns: 1
     ipv6_subprefix: 1
@@ -35,7 +40,7 @@ networks:
 
   - vid: 40
     role: dhcp
-    prefix: 10.31.172.128/25
+    prefix: 10.248.13.128/25
     ipv6_subprefix: 0
     inbound_filtering: true
     enforce_client_isolation: true
@@ -49,11 +54,11 @@ networks:
   - role: tunnel
     ifname: ts_wg0
     mtu: 1280
-    prefix: 10.31.172.32/32
+    prefix: 10.248.13.8/32
     wireguard_port: 51820
 
   - role: tunnel
     ifname: ts_wg1
     mtu: 1280
-    prefix: 10.31.172.33/32
+    prefix: 10.248.13.9/32
     wireguard_port: 51821

--- a/roles/cfg_openwrt/templates/common/config/system.j2
+++ b/roles/cfg_openwrt/templates/common/config/system.j2
@@ -3,7 +3,7 @@ config system
         option zonename '{{ zonename }}'
         option timezone '{{ timezone }}'
         option ttylogin '0'
-        option log_size '64'
+        option log_size '{{ log_size }}'
         option urandom_seed '0'
         option compat_version '9.9' # hardcoded to a bbb-configs exclusive version identifier, matches patch in image builder, because we dont retain device config.
 {% if role == 'corerouter' or role  == 'gateway' %}


### PR DESCRIPTION
There's been a lot of progress on mt76 wifi bugs recently. Fewer crashes, fewer meshing issues. https://github.com/openwrt/mt76/commits/master/

The custom imagebuilder I used has the latest commit from openwrt/mt76.git and also a few kernel options for debugging: https://github.com/pktpls/falter-builter/commit/b2eaa19b8f74a7c7bd5c791fcd44af9d7dbfb6b6