### PR TITLE
ak36-gw: add v6 uplink

### DIFF
--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -52,7 +52,7 @@ ipv6_prefix: 2001:bf7:750:4000::/56
 uplink:
   ifname: eth0
   ipv4: 77.87.51.11/25
-  # ipv6: ToDo
+  ipv6: 2001:bf7:b103:1::11/64
 
 mgmt:
   ifname: eth1.42

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -7,14 +7,14 @@ longitude: 13.369589
 altitude: 75
 community: true
 
+peer_asn: 44194
+
 hosts:
 
   - hostname: ak36-gw
     role: gateway
     model: "x86-64"
     image_search_pattern: "*-ext4-combined.img*"
-    ak36__disabled_services__to_merge:
-      - "bird"
 
 snmp_devices:
   - hostname: ak36-poe-roof

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -52,7 +52,7 @@ ipv6_prefix: 2001:bf7:750:4000::/56
 uplink:
   ifname: eth0
   ipv4: 77.87.51.11/25
-  ipv6: 2001:bf7:b103:1::11/64
+  ipv6: 2001:bf7:b103:1312::1/127
 
 mgmt:
   ifname: eth1.42

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -7,6 +7,7 @@ longitude: 13.369589
 altitude: 75
 community: true
 
+local_asn: 65023
 peer_asn: 44194
 
 hosts:

--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -52,7 +52,7 @@ ipv6_prefix: 2001:bf7:750:4000::/56
 uplink:
   ifname: eth0
   ipv4: 77.87.51.11/25
-  ipv6: 2001:bf7:b103:1312::1/127
+  ipv6: 2001:bf7:b301:1312::1/127
 
 mgmt:
   ifname: eth1.42


### PR DESCRIPTION
Add a v6 address to the ak-gw.
The router will announce a default route and accept the announcement of the /44s but won't propagate them to the IXes