### PR TITLE
gateway: allow incoming to radbahn, for mt76 debugging

### DIFF
--- a/group_vars/role_gateway/general.yml
+++ b/group_vars/role_gateway/general.yml
@@ -94,6 +94,8 @@ inbound_allow:
     dst: 2001:bf7:830:1029::/64
   - name: 'cryptpad.berlin noc@stadtfunk.net'
     dst: 2001:bf7:750:5b00::/128
+  - name: 'radbahn mt76 testing'
+    dst: 2001:bf7:830:c000::/56
 #  - name: Rule Description (mandatory)
 #    dst: Destination IP (mandatory)
 #    src: Source IP


### PR DESCRIPTION
So nbd can access it and gather data live. Already applied on ohlauer-gw and saarbruecker-gw.