### PR TITLE
Implement IPv4 Route Policy to prefer babel routes

### DIFF
--- a/group_vars/role_corerouter/imageprofile.yml
+++ b/group_vars/role_corerouter/imageprofile.yml
@@ -1,5 +1,7 @@
 ---
 role_corerouter__packages__to_merge:
+  - bird2
+  - bird2c
   - babeld
   - luci-app-babeld
   - collectd-mod-dhcpleases

--- a/roles/cfg_openwrt/files/common/iproute2/rt_tables
+++ b/roles/cfg_openwrt/files/common/iproute2/rt_tables
@@ -1,0 +1,20 @@
+#
+# reserved values
+#
+128	prelocal
+255	local
+254	main
+253	default
+
+0	unspec
+#
+# local
+#
+#1	inr.ruhep
+
+10	babel-ff
+11	babel-default
+12      babel-src
+20      olsr-ff
+21	olsr-default
+

--- a/roles/cfg_openwrt/files/corerouter/babeld.conf
+++ b/roles/cfg_openwrt/files/corerouter/babeld.conf
@@ -1,0 +1,1 @@
+export-table 12

--- a/roles/cfg_openwrt/files/corerouter/bird.conf
+++ b/roles/cfg_openwrt/files/corerouter/bird.conf
@@ -1,0 +1,47 @@
+log syslog all;
+debug protocols all;
+
+ipv4 table babel_src;
+ipv4 table babel_ff;
+ipv4 table babel_default;
+
+protocol device {
+}
+
+protocol kernel {
+        learn;
+        kernel table 12;
+	ipv4 {
+                table babel_src;
+		import all;
+	};
+}
+
+protocol kernel { 
+        kernel table 10;
+	ipv4 {
+                table babel_ff;
+		export all;
+	};
+}
+
+protocol kernel { 
+        kernel table 11;
+        ipv4 {             
+        	table babel_default;
+                export all;
+        };                 
+}
+
+
+protocol pipe {
+	table babel_src;
+	peer table babel_ff;
+	export where net != 0.0.0.0/0;
+}
+
+protocol pipe {
+        table babel_src;
+        peer table babel_default;
+        export where net = 0.0.0.0/0;
+} 

--- a/roles/cfg_openwrt/files/corerouter/iproute2/rt_tables
+++ b/roles/cfg_openwrt/files/corerouter/iproute2/rt_tables
@@ -1,0 +1,1 @@
+../../common/iproute2/rt_tables

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -2,6 +2,28 @@
 {% set profile = wireless_profiles | selectattr('name', 'equalto', wireless_profile) | list | first %}
 {% set wifi_networks = profile | json_query('ifaces[].network') | default([], true) %}
 
+
+# Babel inserts into seperate route table, add that to lookup list for IPv6
+config rule6
+	option priority 33000
+        option lookup 'babel-src'
+
+# IPv4 Soft Migration by priotizing Babel over OLSR
+config rule
+	option priority 33100
+	option lookup 'babel-ff'
+
+config rule
+        option priority 33101
+        option lookup 'olsr-ff'
+
+config rule
+	option priority 33200
+	option lookup 'babel-default'
+config rule
+        option priority 33201
+        option lookup 'olsr-default'
+
 config interface 'loopback'
 	option device 'lo'
 	option proto 'static'

--- a/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/olsrd.j2
@@ -40,6 +40,8 @@ config olsrd
 	option OlsrPort '698'
 	option Willingness '3'
 	option TosValue '16'
+	option RtTable '20'
+	option RtTableDefault '21'
 
 config InterfaceDefaults
 	option MidValidityTime '500.0'


### PR DESCRIPTION
Implement following changes which are preparing the migration towards using babel also for IPv4 - #964

- Add new Routing Tables to avoid babel routes compete with olsrd, which could lead to routing loops. We have to ensure that the routes get installed only in the appropriate tables, never in the default/main.
    ```
    babel-default # Contains default routes from babel
    babel-ff # Contains freifunk routes (hna) from babel
    olsr-default # Contains default routes from olsr
    olsr-ff #  Contains freifunk routes (hna) from olsr
    ```
- Setup routing policy in following order:
    ```
    babel-ff -> olsrd-ff -> babel-default -> olsrd-default
    ```

- Ensure that olsrd and babeld install IPv4 routes only in the appropriate tables. Unfortunately babeld is not able to install routes in different policies, therefore routes are installed in "intermediate" table `babel-src`, from which they are leaked conditionally into `babel-ff` and `babel-default` using bird2. In addition it has to be ensured that the babel-src table is also used to lookup IPv6 targets.
 
With these changes in place we have ensured that babeld and olsrd routes never compete and babel is prefered whenever a route is there, but if not it is routed using olsr. 

