### PR TITLE
Configure olsrd6 in order to fix traceroute name lookup

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -45,5 +45,5 @@ all_luci_base__packages__to_merge:
   - uhttpd
   - uhttpd-mod-ubus
 
-all_disabled_services__to_merge:
-  - "olsrd6"
+#all_disabled_services__to_merge:
+#  - "olsrd6"

--- a/roles/cfg_openwrt/templates/corerouter/config/olsrd6.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/olsrd6.j2
@@ -1,0 +1,53 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+config LoadPlugin
+	option library 'olsrd_nameservice'
+	option suffix '.olsr6'
+	option hosts_file '/tmp/hosts/olsr6'
+	option latlon_file '/tmp/_unused_olsr6_latlon.js'
+	option services_file '/tmp/_unused_olsr6_services'
+
+config LoadPlugin
+        option accept '::'
+        option ipv6only 'true'
+        option library 'olsrd_jsoninfo'
+        option ignore '0'
+
+config olsrd
+	option IpVersion '6'
+	option FIBMetric 'flat'
+	option AllowNoInt 'yes'
+	option TcRedundancy '2'
+	option NatThreshold '0.75'
+	option LinkQualityAlgorithm 'etx_ff'
+	option SmartGateway 'no'
+	option Pollrate '0.025'
+	option LinkQualityLevel '2'
+	option OlsrPort '698'
+	option Willingness '3'
+	option TosValue '16'
+	option RtTable '666'
+	option RtTableDefault '666'
+
+config InterfaceDefaults
+	option MidValidityTime '500.0'
+	option TcInterval '2.0'
+	option HnaValidityTime '125.0'
+	option HelloValidityTime '125.0'
+	option TcValidityTime '500.0'
+	option MidInterval '50.0'
+	option HelloInterval '15.0'
+	option HnaInterval '30.0'
+
+{% for network in networks | selectattr('role', 'equalto', 'mesh') %}
+config Interface
+	option ignore '0'
+	option interface '{{ network['name'] if 'name' in network else network['role'] }}'
+	option Mode '{{ 'ether' if network.get('ptp') else 'mesh' }}'
+{% endfor %}
+
+{% for tunnel in networks | selectattr('role', 'equalto', 'tunnel') %}
+config Interface
+	option interface '{{ tunnel['ifname'] }}'
+	option Mode 'ether'
+	option ignore 0
+{% endfor %}

--- a/roles/cfg_openwrt/templates/gateway/config/olsrd6.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/olsrd6.j2
@@ -1,0 +1,49 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+config LoadPlugin
+	option library 'olsrd_nameservice'
+	option suffix '.olsr6'
+	option hosts_file '/tmp/hosts/olsr6'
+	option latlon_file '/tmp/_unused_olsr6_latlon.js'
+	option services_file '/tmp/_unused_olsr6_services'
+
+config LoadPlugin
+        option accept '::'
+        option ipv6only 'true'
+        option library 'olsrd_jsoninfo'
+        option ignore '0'
+
+config olsrd
+	option IpVersion '6'
+	option FIBMetric 'flat'
+	option AllowNoInt 'yes'
+	option TcRedundancy '2'
+	option NatThreshold '0.75'
+	option LinkQualityAlgorithm 'etx_ff'
+	option SmartGateway 'no'
+	option Pollrate '0.025'
+	option LinkQualityLevel '2'
+	option OlsrPort '698'
+	option Willingness '3'
+	option TosValue '16'
+	option RtTable '666'
+	option RtTableDefault '666'
+
+config InterfaceDefaults
+	option MidValidityTime '500.0'
+	option TcInterval '2.0'
+	option HnaValidityTime '125.0'
+	option HelloValidityTime '125.0'
+	option TcValidityTime '500.0'
+	option MidInterval '50.0'
+	option HelloInterval '15.0'
+	option HnaInterval '30.0'
+
+{% if mesh_links is defined and mesh_links|length>0 %}
+  {% for interface in mesh_links %}
+config Interface
+	option ignore '0'
+	option interface '{{ interface['name'] }}'
+	option Mode '{{ 'ether' if interface.get('ptp') else 'mesh' }}'
+  {% endfor %}
+{% endif %}
+


### PR DESCRIPTION
Not kidding...

Quick procedure to deploy without reflashing:


```
rm -r tmp
ansible-playbook play.yml -t config -l sama-core,zwingli-core
cd tmp/configs
for i in *; do scp -O $i/etc/config/olsrd6 root@$i.olsr:/etc/config/; ssh root@$i.olsr /etc/init.d/olsrd6 start; ssh root@$i.olsr /etc/init.d/olsrd6 enable; done
```