### PR TITLE
emma: new corerouter, fritzbox again unstable

### DIFF
--- a/locations/emma.yml
+++ b/locations/emma.yml
@@ -9,8 +9,7 @@ community: true
 hosts:
   - hostname: emma-core
     role: corerouter
-    model: "avm_fritzbox-4040"
-    wireless_profile: freifunk_default
+    model: "mikrotik_routerboard-750gr3"
 
 snmp_devices:
   - hostname: emma-switch-no


### PR DESCRIPTION
Fritzbox was not a good replacement for the bricked corerouter in April, but it was the only device I had at hand. It has regular crashes and outages, so bad that we're force-rebooting it every hour. We knew that before, but there was no time to grab a better device.

Now switch to a Routerboard 750gr3, which isn't as fast as the previous Belkin RT3200, but is rock solid stable.