### PR TITLE
olsrd: unify suffix

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/olsrd6.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/olsrd6.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 config LoadPlugin
 	option library 'olsrd_nameservice'
-	option suffix '.olsr6'
+	option suffix '.olsr'
 	option hosts_file '/tmp/hosts/olsr6'
 	option latlon_file '/tmp/_unused_olsr6_latlon.js'
 	option services_file '/tmp/_unused_olsr6_services'

--- a/roles/cfg_openwrt/templates/gateway/config/olsrd6.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/olsrd6.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 config LoadPlugin
 	option library 'olsrd_nameservice'
-	option suffix '.olsr6'
+	option suffix '.olsr'
 	option hosts_file '/tmp/hosts/olsr6'
 	option latlon_file '/tmp/_unused_olsr6_latlon.js'
 	option services_file '/tmp/_unused_olsr6_services'


### PR DESCRIPTION
This PR changes the suffix for olsrd6 also to olsr instead of olsr6 so a connections or trace to a remote node can always be established using the same hostname.

```
root@w38b-core:~# mtr -r -b -w -4 k12-core.olsr && mtr -r -b -w -6 k12-core.olsr
Start: 2024-09-20T18:23:00+0200
HOST: w38b-core                               Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- mid5.sama-core.olsr (10.31.79.182)       0.0%    10    1.8   1.8   1.5   2.2   0.2
  2.|-- mid3.saarbruecker-gw.olsr (10.31.83.57)  0.0%    10    3.9   3.8   2.3   7.8   2.0
  3.|-- segen-core.olsr (10.31.6.64)             0.0%    10    9.5   5.1   2.7   9.5   2.1
  4.|-- k12-core.olsr (10.31.158.133)            0.0%    10    6.1   7.7   4.4  15.6   3.8
Start: 2024-09-20T18:23:15+0200
HOST: w38b-core                                   Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- mid11.rhnk-core.olsr (2001:bf7:820:10e6::1)  0.0%    10    1.5   2.3   1.5   5.1   1.0
  2.|-- mid2.ak36-gw.olsr (2001:bf7:750:4001::6)     0.0%    10    2.4   4.5   2.4   7.3   1.8
  3.|-- 2001:bf7:760:2201::1 (2001:bf7:760:2201::1)  0.0%    10    4.3   4.7   3.2  10.2   2.1
  4.|-- segen-core.olsr (2001:bf7:760:10ff::1)       0.0%    10    6.0   5.2   4.3   9.8   1.7
  5.|-- k12-core.olsr (2001:bf7:760:2af5::1)         0.0%    10   17.8  14.7  10.0  20.3   3.5

```