### PR TITLE
bbbvpn is on another interface

### DIFF
--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -98,7 +98,7 @@ mesh_links:
     ptp: true
 
   - name: mesh_bbbvpn
-    ifname: eth1.198
+    ifname: eth2
     ipv4: 10.31.130.164/32
     # the bbb-vpn setup is ipv4-only for now
     # ipv6: 2001:bf7:750:4001::5/128


### PR DESCRIPTION
Das alte vlan war auf dem switch nur auf:
- ak-gw
- ak36-testbox1g
- ak36-testbox10g
verbunden


eth2 ist nun der direkte link zu: https://github.com/freifunk-berlin/bbb-configs/blob/main/locations/strom.yml#L85