### PR TITLE
wikiupdater: fix building of variable

### DIFF
--- a/roles/cfg_openwrt/tasks/wikiupdater.yml
+++ b/roles/cfg_openwrt/tasks/wikiupdater.yml
@@ -12,7 +12,7 @@
     mode: "644"
 
 - name: wikiupdater | Update article
-  script: ../files/wiki/update.py -l "{{ location }}"  --file "{{ wikiupdater_dir }}/{{ group_names[0] | split('_') | last }}.txt"
+  script: ../files/wiki/update.py -l "{{ location }}"  --file "{{ wikiupdater_dir }}/{{ location }}.txt"
   register: wiki_res
   changed_when: '"UPDATED" in wiki_res.stdout'
   args:


### PR DESCRIPTION
Get rid of the dirty way the variable was constructed to make it work with locations that have a `-` in their name