### PR TITLE
newyorck: make uplink v50 untagged

### DIFF
--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -106,6 +106,7 @@ networks:
 
   - vid: 50
     role: uplink
+    untagged: true
 
   - role: tunnel
     ifname: ts_wg0


### PR DESCRIPTION
Makes vlan 50 untagged, so that the uplink can be plugged directly into the router. The goal is to simplify the wired setup to make it easier to understand and debug for non technical users.

(Already deployed.)