### PR TITLE
Refactor some common network config features into libnetwork

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -1,12 +1,10 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
-{% set profile = wireless_profiles | selectattr('name', 'equalto', wireless_profile) | list | first %}
-{% set wifi_networks = profile | json_query('ifaces[].network') | default([], true) %}
-
+{% import 'libraries/network.j2' as libnetwork with context %}
 
 # Babel inserts into seperate route table, add that to lookup list for IPv6
 config rule6
 	option priority 33000
-        option lookup 'babel-src'
+	option lookup 'babel-src'
 
 # IPv4 Soft Migration by priotizing Babel over OLSR
 config rule
@@ -14,15 +12,15 @@ config rule
 	option lookup 'babel-ff'
 
 config rule
-        option priority 33101
-        option lookup 'olsr-ff'
+	option priority 33101
+	option lookup 'olsr-ff'
 
 config rule
 	option priority 33200
 	option lookup 'babel-default'
 config rule
-        option priority 33201
-        option lookup 'olsr-default'
+	option priority 33201
+	option lookup 'olsr-default'
 
 config interface 'loopback'
 	option device 'lo'
@@ -41,49 +39,31 @@ config interface 'loopback'
 
 
 {% for network in networks | selectattr('vid', 'defined') %}
-  {% set name = network['name'] if 'name' in network else network['role'] %}
-  {% set vid = network['vid']|string %}
-  {% set untagged = network.get('untagged') %}
-  {% if 'ifname' in network %}
-    {% set port = network['ifname'] + ('' if untagged else '.' + vid) %}
-  {% elif dsa_ports is defined %}
-    {% set port = 'switch0' + '.' + vid %}
-  {% elif (switch_ports|default(0) > 0) %}
-    {% set port = int_port + '.' + vid %}
-  {% else %}
-    {% set port = int_port + ('' if untagged else '.' + vid) %}
-  {% endif %}
-  {% set bridge_name = 'br-' + name %}
-  {% set bridge_needed = name in wifi_networks or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and network['role'] == 'uplink' and network.get('uplink_mode') != 'direct') %}
-  {% set port_needed = not (role == 'corerouter' and network.get('mesh_ap') == inventory_hostname) %}
+  {% set name = libnetwork.getUciIfname(network) %}
 
   {%- if (role == 'corerouter' and network['role'] == 'mesh') or ('assignments' in network and inventory_hostname in network['assignments'])
-     or name in wifi_networks
+     or name in libnetwork.getWirelessNetworks() | from_json
      or network.get('mesh_ap') == inventory_hostname
      or (role == 'corerouter' and network['role'] == 'uplink' and network.get('uplink_mode') != 'direct')
      %}
 config interface '{{ name }}'
-    {% if port_needed %}
-        {% if bridge_needed %}
-        option device '{{ (bridge_name if bridge_name | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
-        {% else %}
-        option device '{{ port }}'
-        {% endif %}
+    {% if libnetwork.isPortNeeded(network) | from_json %}
+	option device '{{ libnetwork.getIfname(network) }}'
     {% endif %}
     {% if network.get('enforce_client_isolation') and role == 'corerouter' and
-          not bridge_needed %}
+       not libnetwork.isBridgeNeeded(network) | from_json %}
 	option macaddr '02:00:00:00:00:01'
     {% endif %}
     {% if 'assignments' in network and inventory_hostname in network['assignments'] %}
 	option proto 'static'
 	option ipaddr '{{ network['prefix'] | ansible.utils.ipaddr(network['assignments'][inventory_hostname]) }}'
-	{% if role != "corerouter" and 'dns' in network %}
+       {% if role != "corerouter" and 'dns' in network %}
 	option dns '{{ network['prefix'] | ansible.utils.ipaddr(network['dns']) | ansible.utils.ipaddr('address') }}'
-        {% endif %}
-	{% if 'gateway' in network and 'assignments' in network and network['assignments'][inventory_hostname] != network['gateway'] %}
+       {% endif %}
+       {% if 'gateway' in network and 'assignments' in network and network['assignments'][inventory_hostname] != network['gateway'] %}
 	option gateway '{{ network['prefix'] | ansible.utils.ipaddr(network['gateway']) | ansible.utils.ipaddr('address') }}'
-        {% endif %}
-        {% if role != 'corerouter' and 'ipv6_subprefix' in network %}
+       {% endif %}
+       {% if role != 'corerouter' and 'ipv6_subprefix' in network %}
 
 # IPv6 Address comes via SLAAC and RA. See sysctl, there it is enabled
 # The reason is to get rid of the userspace daemon
@@ -105,14 +85,14 @@ config interface '{{ name }}'
     {% endif %}
   {% endif %}
 
-  {% if port_needed and bridge_needed %}
+  {% if libnetwork.isPortNeeded(network) | from_json and libnetwork.isBridgeNeeded(network) | from_json %}
 config device
-	option name '{{ (bridge_name if bridge_name | length <= 15) | mandatory('The generated inteface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') }}'
-        option type 'bridge'
+	option name '{{ libnetwork.getBridgeIfname(network) }}'
+	option type 'bridge'
     {% if network.get('enforce_client_isolation') and role == 'corerouter' %}
 	option macaddr '02:00:00:00:00:01'
     {% endif %}
-	list ports '{{ port }}'
+	list ports '{{ libnetwork.getPortIfname(network) }}'
   {% endif %}
 
 {% endfor %}

--- a/roles/cfg_openwrt/templates/libraries/network.j2
+++ b/roles/cfg_openwrt/templates/libraries/network.j2
@@ -1,0 +1,59 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
+
+{# Retrieve the layer 3 interface name of a network. #}
+{% macro getIfname(network) %}
+    {% set ifname = "" %}
+    {% if isBridgeNeeded(network) | from_json %}
+        {% set ifname = getBridgeIfname(network) %}
+    {% else %}
+        {% set ifname = getPortIfname(network) %}
+    {% endif %}
+
+{{- (ifname if ifname | length <= 15) | mandatory('The generated interface name exceeds the 15 characters limit of the linux kernel. Try to shorten the name to resolve this.') -}}
+{% endmacro %}
+
+{# Retrieve the Port Name of a network. This is either a physical vlan subinterface, or the switch vlan subinterface from DSA #}
+{% macro getPortIfname(network) %}
+    {% set vid = network['vid']|string %}
+    {% set untagged = network.get('untagged') %}
+    {% if 'ifname' in network %}
+        {% set port = network['ifname'] + ('' if untagged else '.' + vid) %}
+    {% elif dsa_ports is defined %}
+        {% set port = 'switch0' + '.' + vid %}
+    {% elif (switch_ports|default(0) > 0) %}
+        {% set port = int_port + '.' + vid %}
+    {% else %}
+        {% set port = int_port + ('' if untagged else '.' + vid) %}
+    {% endif %}
+{{- port -}}
+{% endmacro %}
+
+{# Retrieve the bridge interface name of a network. This does not check if a bridge is actually needed #}
+{% macro getBridgeIfname(network) %}
+{{- 'br-' + getUciIfname(network) -}}
+{% endmacro %}
+
+{# Retrieve the UCI/OpenWRT internal name of a network. #}
+{% macro getUciIfname(network) %}
+{{- network['name'] if 'name' in network else network['role'] -}}
+{% endmacro %}
+
+{# Do we need to create a logical bridge for that network to bridge to wireless interface or are we not participating. This does not affect the switch configuration
+ # Warning: returns a bool. Use |from_json filter when calling #}
+{% macro isBridgeNeeded(network) %}
+{{- (getUciIfname(network) in getWirelessNetworks() or network.get('mesh_ap') == inventory_hostname or (role == 'corerouter' and network['role'] == 'uplink' and network.get('uplink_mode') != 'direct')) | to_json -}}
+{% endmacro %}
+
+{# Do we need to configure a port or is this network only connected local (e.g. Mesh Endpoint on the core router)
+ # Warning: returns a bool. Use |from_json filter when calling #}
+{% macro isPortNeeded(network) %}
+{{- (not (role == 'corerouter' and network.get('mesh_ap') == inventory_hostname)) | to_yaml -}}
+{% endmacro %}
+
+{# Retrieve the networks which shall be bridged to wifi
+ # Returns a list of  bbb-config network name (network['name'])
+ # Warning: returns a list. Use |from_json filter when calling #}
+{% macro getWirelessNetworks() %}
+    {% set selected_wireless_profile = wireless_profiles | selectattr('name', 'equalto', wireless_profile) | list | first %}
+{{- selected_wireless_profile | json_query('ifaces[].network') | default([], true) | to_json -}}
+{% endmacro %}


### PR DESCRIPTION
In order to avoid code redundancy i factored out some of the lookup code of config/network.j2 into macros in libraries/network.j2.

I did not fix indentation of config/network.j2, except the ones which affect the output.

--check --diff run results for /etc/config/network:

wilgu10-int:
```
--- before: /home/spolack/git/bbb-configs/tmp/configs/wilgu10-int/etc/config/network
+++ after: /home/spolack/.ansible/tmp/ansible-local-216624zq1d7khx/tmpcf1vd_xh/network.j2
@@ -1,9 +1,8 @@
-
 
 # Babel inserts into seperate route table, add that to lookup list for IPv6
 config rule6
 	option priority 33000
-        option lookup 'babel-src'
+	option lookup 'babel-src'
 
 # IPv4 Soft Migration by priotizing Babel over OLSR
 config rule
@@ -11,15 +10,15 @@
 	option lookup 'babel-ff'
 
 config rule
-        option priority 33101
-        option lookup 'olsr-ff'
+	option priority 33101
+	option lookup 'olsr-ff'
 
 config rule
 	option priority 33200
 	option lookup 'babel-default'
 config rule
-        option priority 33201
-        option lookup 'olsr-default'
+	option priority 33201
+	option lookup 'olsr-default'
 
 config interface 'loopback'
 	option device 'lo'
@@ -75,7 +74,7 @@
 
 
 config interface 'mgmt'
-        option device 'switch0.42'
+	option device 'switch0.42'
 	option proto 'static'
 	option ipaddr '10.36.190.178/28'
 	option dns '10.36.190.177'
@@ -89,21 +88,21 @@
 
 
 config interface 'dhcp'
-        option device 'br-dhcp'
+	option device 'br-dhcp'
 	option proto 'none'
 
 config device
 	option name 'br-dhcp'
-        option type 'bridge'
+	option type 'bridge'
 	list ports 'switch0.40'
 
 config interface 'prdhcp'
-        option device 'br-prdhcp'
+	option device 'br-prdhcp'
 	option proto 'none'
 
 config device
 	option name 'br-prdhcp'
-        option type 'bridge'
+	option type 'bridge'
 	list ports 'switch0.41'
 
 

changed: [wilgu10-int] => (item=config/network.j2)
```

wilgu10-core:
```
--- before: /home/spolack/git/bbb-configs/tmp/configs/wilgu10-core/etc/config/network
+++ after: /home/spolack/.ansible/tmp/ansible-local-216624zq1d7khx/tmpe90gw4id/network.j2
@@ -1,9 +1,8 @@
-
 
 # Babel inserts into seperate route table, add that to lookup list for IPv6
 config rule6
 	option priority 33000
-        option lookup 'babel-src'
+	option lookup 'babel-src'
 
 # IPv4 Soft Migration by priotizing Babel over OLSR
 config rule
@@ -11,15 +10,15 @@
 	option lookup 'babel-ff'
 
 config rule
-        option priority 33101
-        option lookup 'olsr-ff'
+	option priority 33101
+	option lookup 'olsr-ff'
 
 config rule
 	option priority 33200
 	option lookup 'babel-default'
 config rule
-        option priority 33201
-        option lookup 'olsr-default'
+	option priority 33201
+	option lookup 'olsr-default'
 
 config interface 'loopback'
 	option device 'lo'
@@ -70,58 +69,58 @@
 
 
 config interface 'mesh_sama'
-        option device 'switch0.10'
+	option device 'switch0.10'
 	option proto 'static'
 	option ipaddr '10.230.210.104/32'
 	option ip6addr '2001:bf7:860:9ff::1/128'
 
 
 config interface 'mesh_zwingli'
-        option device 'switch0.11'
+	option device 'switch0.11'
 	option proto 'static'
 	option ipaddr '10.230.210.105/32'
 	option ip6addr '2001:bf7:860:9fe::1/128'
 
 
 config interface 'mesh_east_2g'
-        option device 'switch0.20'
+	option device 'switch0.20'
 	option proto 'static'
 	option ipaddr '10.230.210.106/32'
 	option ip6addr '2001:bf7:860:9fd::1/128'
 
 
 config interface 'mgmt'
-        option device 'switch0.42'
+	option device 'switch0.42'
 	option proto 'static'
 	option ipaddr '10.36.190.177/28'
 	option ip6addr '2001:bf7:860:901::1/64'
 
 
 config interface 'dhcp'
-        option device 'br-dhcp'
+	option device 'br-dhcp'
 	option proto 'static'
 	option ipaddr '10.36.164.65/27'
 	option ip6addr '2001:bf7:860:900::1/64'
 
 config device
 	option name 'br-dhcp'
-        option type 'bridge'
+	option type 'bridge'
 	option macaddr '02:00:00:00:00:01'
 	list ports 'switch0.40'
 
 config interface 'prdhcp'
-        option device 'br-prdhcp'
+	option device 'br-prdhcp'
 	option proto 'static'
 	option ipaddr '10.31.154.97/28'
 	option ip6addr '2001:bf7:860:90a::1/64'
 
 config device
 	option name 'br-prdhcp'
-        option type 'bridge'
+	option type 'bridge'
 	list ports 'switch0.41'
 
 config interface 'w10host'
-        option device 'switch0.50'
+	option device 'switch0.50'
 	option proto 'static'
 	option ipaddr '10.31.124.33/28'
 	option ip6addr '2001:bf7:860:932::1/64'

changed: [wilgu10-core] => (item=config/network.j2)
```