### PR TITLE
Fix mesh metrics

### DIFF
--- a/locations/ak36.yml
+++ b/locations/ak36.yml
@@ -80,21 +80,21 @@ mesh_links:
     ifname: eth1.10
     ipv4: 10.31.130.160/32
     ipv6: 2001:bf7:750:4001::1/128
-    metric: 1024
+    mesh_metric: 1024
     ptp: true
 
   - name: mesh_flughafen
     ifname: eth1.11
     ipv4: 10.31.130.161/32
     ipv6: 2001:bf7:750:4001::2/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
   - name: mesh_dtmb
     ifname: eth1.12
     ipv4: 10.31.130.162/32
     ipv6: 2001:bf7:750:4001::3/128
-    metric: 1024
+    mesh_metric: 1024
     ptp: true
 
   - name: mesh_bbbvpn
@@ -102,21 +102,21 @@ mesh_links:
     ipv4: 10.31.130.164/32
     # the bbb-vpn setup is ipv4-only for now
     # ipv6: 2001:bf7:750:4001::5/128
-    metric: 1024
+    mesh_metric: 1024
     ptp: true
 
   - name: mesh_rhnk
     ifname: eth1.14
     ipv4: 10.31.130.165/32
     ipv6: 2001:bf7:750:4001::6/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
   - name: mesh_teufel
     ifname: eth1.15
     ipv4: 10.31.130.166/32
     ipv6: 2001:bf7:750:4001::7/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
 # OLSR Announce SmartGateway

--- a/locations/dragonkiez-adlerhalle.yml
+++ b/locations/dragonkiez-adlerhalle.yml
@@ -37,7 +37,6 @@ networks:
     role: mesh
     prefix: 10.31.34.44/30
     ipv6_subprefix: -1
-    metric: 1024
     ptp: true
     assignments:
       dragonkiez-adlerhalle: 1

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -36,7 +36,6 @@ networks:
     role: mesh
     prefix: 10.31.23.112/30
     ipv6_subprefix: -1
-    metric: 1024
     ptp: true
     assignments:
       dragonkiez-buero: 1

--- a/locations/dragonkiez-dorfplatz.yml
+++ b/locations/dragonkiez-dorfplatz.yml
@@ -41,7 +41,6 @@ networks:
     role: mesh
     prefix: 10.31.28.248/30
     ipv6_subprefix: -1
-    metric: 1024
     ptp: true
     assignments:
       dragonkiez-dorfplatz: 1

--- a/locations/dragonkiez-kiezraum.yml
+++ b/locations/dragonkiez-kiezraum.yml
@@ -31,7 +31,6 @@ networks:
     name: mesh_rhxb
     prefix: 10.31.92.240/32
     ipv6_subprefix: -1
-    metric: 1024
     ptp: true
 
   - vid: 40

--- a/locations/dragonkiez-rathausblock-miami.yml
+++ b/locations/dragonkiez-rathausblock-miami.yml
@@ -45,7 +45,6 @@ networks:
     role: mesh
     prefix: 10.31.30.32/30
     ipv6_subprefix: -1
-    metric: 1024
     ptp: true
     assignments:
       dragonkiez-rathausblock-miami: 1

--- a/locations/l105.yml
+++ b/locations/l105.yml
@@ -61,21 +61,21 @@ mesh_links:
     ifname: eth1.10
     ipv4: 10.31.127.160/32
     ipv6: 2001:bf7:750:3f01::1/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
   # - name: mesh_tu
   #   ifname: eth1.11
   #   ipv4: 10.31.127.161/32
   #   ipv6: 2001:bf7:750:3f01::2/128
-  #   metric: 128
+  #   mesh_metric: 128
   #   ptp: true
 
   - name: mesh_bbbvpn
     ifname: eth1.32
     ipv4: 10.31.127.162/32
     ipv6: 2001:bf7:750:3f01::3/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
 # Downlink IPv4 is in net announced by emma.

--- a/locations/ohlauer.yml
+++ b/locations/ohlauer.yml
@@ -52,7 +52,7 @@ mesh_links:
 # Downlink IPv4 is in net announced by emma.
 
 # OLSR Announce SmartGateway
-sgw: "100000 100000"
+sgw: "1000000 1000000"
 
 # Tunnel metric 1024 as most internet uplinks will hardly reach 40MBit/s
 # 2001:bf7:830:8300::/56 is the base prefix

--- a/locations/ohlauer.yml
+++ b/locations/ohlauer.yml
@@ -46,7 +46,7 @@ mesh_links:
     ifname: lan3.10
     ipv4: 10.31.11.96/32
     ipv6: 2001:bf7:830:8301::/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
 # Downlink IPv4 is in net announced by emma.

--- a/locations/saarbruecker.yml
+++ b/locations/saarbruecker.yml
@@ -52,21 +52,21 @@ mesh_links:
     ifname: lan0.10
     ipv4: 10.31.83.56/32
     ipv6: 2001:bf7:760:2200::1/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
   - name: mesh_sama
     ifname: lan0.11
     ipv4: 10.31.83.57/32
     ipv6: 2001:bf7:760:2200::2/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
   - name: mesh_segen
     ifname: lan0.12
     ipv4: 10.31.83.58/32
     ipv6: 2001:bf7:760:2200::3/128
-    metric: 128
+    mesh_metric: 128
     ptp: true
 
 # Downlink IPv4 is in net announced by emma.

--- a/locations/strom.yml
+++ b/locations/strom.yml
@@ -79,14 +79,14 @@ mesh_links:
     ifname: eth0.1310
     ipv4: 10.31.48.2/32
     ipv6: 2001:bf7:750:2a02::/128
-    metric: 128
+    mesh_metric: 128
 
   # This interface is IPv4 only
   - name: mesh_bbbvpn
     ifname: eth0.1312
     ipv4: 10.31.48.3/32
     # ipv6: 2001:bf7:750:2a03::/128
-    metric: 1024
+    mesh_metric: 1024
     ptp: true
 
   - name: mesh_no

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -50,8 +50,8 @@ networks:
     ipv6_subprefix: -10
     ptp: true
     # prefer routing via RHNK over SAMA
-    mesh_metric: 192
-    mesh_metric_lqm: ['default 0.85']
+    mesh_metric: 256
+    mesh_metric_lqm: ['default 0.8']
 
   # MESH - RHNK
   - vid: 11
@@ -60,7 +60,7 @@ networks:
     prefix: 10.31.212.34/32
     ipv6_subprefix: -11
     ptp: true
-    mesh_metric: 256
+    mesh_metric: 128
 
   # MESH - 5 GHz 802.11s
   - vid: 20

--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -157,8 +157,8 @@ networks:
     prefix: 10.31.115.36/32
     ipv6_subprefix: -5
     # prefer routing via emma over sama to use ohlauer as gateway)
-    mesh_metric: 192
-    mesh_metric_lqm: ['default 0.85']
+    mesh_metric: 256
+    mesh_metric_lqm: ['default 0.8']
     ptp: true
 
   - vid: 16


### PR DESCRIPTION
Looks like metric was renamed to mesh_metric at some point to be identical accross gateways and corerouters, without properly adjusting all config files:

https://github.com/freifunk-berlin/bbb-configs/blob/28dbaf6b4ea99a6dbd392ac7fc575e82cbcd91fa/roles/cfg_openwrt/templates/gateway/config/babeld.j2#L22

https://github.com/freifunk-berlin/bbb-configs/blob/28dbaf6b4ea99a6dbd392ac7fc575e82cbcd91fa/roles/cfg_openwrt/templates/corerouter/config/babeld.j2#L21

This PR fixes this so we generate proper babeld config files. In addition this fixes the mesh metric at w38b that was still to high.