### PR TITLE
Clean up wireless devices defaults

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -233,8 +233,12 @@ location__wireless_profiles__to_merge:
 
   - name: foobar
     devices:
-      - radio: 11a_standard
       - radio: 11g_standard
+      - radio: 11a_mesh
+      - radio: 11a_standard
+        disabled: false # Enable radio (default)
+        legacy_rates: false # Disable lower bandwith rates (default)
+        country: 'DE' # Set German country code for radio compliance (default)
 
     ifaces:
       - mode: ap

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -234,9 +234,7 @@ location__wireless_profiles__to_merge:
   - name: foobar
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -235,10 +235,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/group_vars/all/wireless_profiles.yml
+++ b/group_vars/all/wireless_profiles.yml
@@ -23,13 +23,10 @@ all__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: mesh
@@ -43,13 +40,10 @@ all__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap
@@ -71,13 +65,10 @@ all__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap
@@ -106,13 +97,10 @@ all__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap
@@ -141,13 +129,10 @@ all__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/group_vars/all/wireless_profiles.yml
+++ b/group_vars/all/wireless_profiles.yml
@@ -20,11 +20,6 @@ all__wireless_profiles__to_merge:
         disabled: true
 
   - name: mesh_only
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: mesh
         mesh_id: Mesh-Freifunk-Berlin
@@ -34,11 +29,6 @@ all__wireless_profiles__to_merge:
         ifname_hint: mesh
 
   - name: ap_only
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net
@@ -56,11 +46,6 @@ all__wireless_profiles__to_merge:
         ieee80211w: 1
 
   - name: freifunk_default
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net
@@ -85,11 +70,6 @@ all__wireless_profiles__to_merge:
         ifname_hint: mesh
 
   - name: freifunk_fw
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: fuerstenwalde.freifunk.net
@@ -114,11 +94,6 @@ all__wireless_profiles__to_merge:
         ifname_hint: mesh
 
   - name: freifunk_hacrafu
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: freifunk.hacrafu.de

--- a/group_vars/all/wireless_profiles.yml
+++ b/group_vars/all/wireless_profiles.yml
@@ -22,11 +22,8 @@ all__wireless_profiles__to_merge:
   - name: mesh_only
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: mesh
@@ -39,11 +36,8 @@ all__wireless_profiles__to_merge:
   - name: ap_only
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap
@@ -64,11 +58,8 @@ all__wireless_profiles__to_merge:
   - name: freifunk_default
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap
@@ -96,11 +87,8 @@ all__wireless_profiles__to_merge:
   - name: freifunk_fw
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap
@@ -128,11 +116,8 @@ all__wireless_profiles__to_merge:
   - name: freifunk_hacrafu
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -72,9 +72,7 @@ location__wireless_profiles__to_merge:
   - name: colbe15
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -70,10 +70,6 @@ location__channel_assignments_11a_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: colbe15
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: colbe15.freifunk.net

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -73,10 +73,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -55,9 +55,7 @@ location__wireless_profiles__to_merge:
   - name: dragonkiez_buero
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -53,10 +53,6 @@ networks:
 
 location__wireless_profiles__to_merge:
   - name: dragonkiez_buero
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: kiezraum2.berlin.freifunk.net

--- a/locations/dragonkiez-buero.yml
+++ b/locations/dragonkiez-buero.yml
@@ -56,10 +56,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/ekke.yml
+++ b/locations/ekke.yml
@@ -93,10 +93,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: ekke
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/ekke.yml
+++ b/locations/ekke.yml
@@ -95,9 +95,7 @@ location__wireless_profiles__to_merge:
   - name: ekke
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/ekke.yml
+++ b/locations/ekke.yml
@@ -96,10 +96,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/hts4.yml
+++ b/locations/hts4.yml
@@ -109,9 +109,7 @@ location__wireless_profiles__to_merge:
   - name: hts4
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/hts4.yml
+++ b/locations/hts4.yml
@@ -107,10 +107,6 @@ location__channel_assignments_11g_standard__to_merge:
 # Wireless profile
 location__wireless_profiles__to_merge:
   - name: hts4
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: Ferienwohnung

--- a/locations/hts4.yml
+++ b/locations/hts4.yml
@@ -110,10 +110,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -113,13 +113,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -110,10 +110,6 @@ location__channel_assignments_11b_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: hway
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -112,11 +112,8 @@ location__wireless_profiles__to_merge:
   - name: hway
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -207,11 +207,8 @@ location__wireless_profiles__to_merge:
   - name: kiehlufer5g
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -208,13 +208,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -205,10 +205,6 @@ location__channel_assignments_11a_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: kiehlufer5g
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -123,13 +123,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -120,10 +120,6 @@ location__channel_assignments_11b_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: kirchhof
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/kirchhof.yml
+++ b/locations/kirchhof.yml
@@ -122,11 +122,8 @@ location__wireless_profiles__to_merge:
   - name: kirchhof
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/koepi.yml
+++ b/locations/koepi.yml
@@ -127,10 +127,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/koepi.yml
+++ b/locations/koepi.yml
@@ -126,9 +126,7 @@ location__wireless_profiles__to_merge:
   - name: koepi
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/koepi.yml
+++ b/locations/koepi.yml
@@ -124,10 +124,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: koepi
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -88,10 +88,6 @@ location__disabled_services__to_merge:
 # For roaming between multiple APs, consider setting 80211w to optional (1).
 location__wireless_profiles__to_merge:
   - name: muggel
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -90,11 +90,8 @@ location__wireless_profiles__to_merge:
   - name: muggel
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/muggel.yml
+++ b/locations/muggel.yml
@@ -91,13 +91,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -156,9 +156,7 @@ location__wireless_profiles__to_merge:
 
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -154,10 +154,6 @@ location__wireless_profiles__to_merge:
 
   - name: newyorck
 
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -157,10 +157,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -187,11 +187,6 @@ location__channel_assignments_11g_standard__to_merge:
 # Wireless profile
 location__wireless_profiles__to_merge:
   - name: noki
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -190,13 +190,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -189,11 +189,8 @@ location__wireless_profiles__to_merge:
   - name: noki
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/q216.yml
+++ b/locations/q216.yml
@@ -115,10 +115,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/q216.yml
+++ b/locations/q216.yml
@@ -112,10 +112,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: q216
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/q216.yml
+++ b/locations/q216.yml
@@ -114,9 +114,7 @@ location__wireless_profiles__to_merge:
   - name: q216
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -130,13 +130,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -129,11 +129,8 @@ location__wireless_profiles__to_merge:
   - name: radbahn
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -127,11 +127,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: radbahn
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/rauchhaus.yml
+++ b/locations/rauchhaus.yml
@@ -140,9 +140,7 @@ location__wireless_profiles__to_merge:
   - name: rauchhaus
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/rauchhaus.yml
+++ b/locations/rauchhaus.yml
@@ -141,10 +141,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/rauchhaus.yml
+++ b/locations/rauchhaus.yml
@@ -138,10 +138,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: rauchhaus
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/stadalbert.yml
+++ b/locations/stadalbert.yml
@@ -136,10 +136,8 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/stadalbert.yml
+++ b/locations/stadalbert.yml
@@ -135,9 +135,7 @@ location__wireless_profiles__to_merge:
   - name: stadalbert
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/stadalbert.yml
+++ b/locations/stadalbert.yml
@@ -133,10 +133,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: stadalbert
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -101,10 +101,8 @@ location__wireless_profiles__to_merge:
   - name: tempelwg
     devices:
       - radio: 11a_standard
-        legacy_rates: false
 
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -102,11 +102,9 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
 
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -99,11 +99,6 @@ location__channel_assignments_11a_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: tempelwg
-    devices:
-      - radio: 11a_standard
-
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -179,11 +179,6 @@ location__channel_assignments_11g_standard__to_merge:
 # Wireless profile
 location__wireless_profiles__to_merge:
   - name: w38b
-    devices:
-      - radio: 11a_standard
-      - radio: 11g_standard
-      - radio: 11a_mesh
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -181,11 +181,8 @@ location__wireless_profiles__to_merge:
   - name: w38b
     devices:
       - radio: 11a_standard
-        legacy_rates: false
       - radio: 11g_standard
-        legacy_rates: false
       - radio: 11a_mesh
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -182,13 +182,10 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
       - radio: 11a_mesh
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/wilgu10.yml
+++ b/locations/wilgu10.yml
@@ -136,10 +136,8 @@ location__wireless_profiles__to_merge:
   - name: wilgu10
     devices:
       - radio: 11a_standard
-        legacy_rates: false
 
       - radio: 11g_standard
-        legacy_rates: false
 
     ifaces:
       - mode: ap

--- a/locations/wilgu10.yml
+++ b/locations/wilgu10.yml
@@ -137,11 +137,9 @@ location__wireless_profiles__to_merge:
     devices:
       - radio: 11a_standard
         legacy_rates: false
-        country: DE
 
       - radio: 11g_standard
         legacy_rates: false
-        country: DE
 
     ifaces:
       - mode: ap

--- a/locations/wilgu10.yml
+++ b/locations/wilgu10.yml
@@ -134,11 +134,6 @@ location__channel_assignments_11g_standard__to_merge:
 
 location__wireless_profiles__to_merge:
   - name: wilgu10
-    devices:
-      - radio: 11a_standard
-
-      - radio: 11g_standard
-
     ifaces:
       - mode: ap
         ssid: berlin.freifunk.net

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -51,6 +51,8 @@ config wifi-device '{{ wd_id }}'
   {% endif %}
   {% if 'legacy_rates' in wd_config %}
 	option legacy_rates '{{ wd_config['legacy_rates']|int }}'
+  {% else %}
+    option legacy_rates '0'
   {% endif %}
   {% if 'disabled' in wd_config %}
 	option disabled '{{ wd_config['disabled']|int }}'

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -46,6 +46,8 @@ config wifi-device '{{ wd_id }}'
   {% endif %}
   {% if 'country' in wd_config %}
 	option country '{{ wd_config['country'] }}'
+  {% else %}
+	option country 'DE'
   {% endif %}
   {% if 'legacy_rates' in wd_config %}
 	option legacy_rates '{{ wd_config['legacy_rates']|int }}'

--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -4,8 +4,13 @@
 # Wifi Config is derived from wireless profile: '{{ wireless_profile }}'
 {% for wd in wireless_devices | default([]) %}
   {% set wd_id = 'radio' + loop.index0|string %}
-  {% set wd_config = profile['devices'] | selectattr('radio', 'contains', wd['name']) | first %}
   {% set wd_ifaces = profile['ifaces'] | default([]) | selectattr('radio', 'contains', wd['name']) %}
+  {% if 'devices' in profile %}
+    {% set wd_config = profile['devices'] | default([]) | selectattr('radio', 'contains', wd['name']) | first %}
+  {% else %}
+    # No config provided, use defaults
+    {% set wd_config = {} %}
+  {% endif %}
 
   {% set channel_assignments = hostvars[inventory_hostname]['channel_assignments_' + wd['name']] %}
   {% set channel_assignment = (channel_assignments[inventory_hostname] | default(channel_assignments['default'])).split('-') %}

--- a/roles/cfg_openwrt/templates/common/nftables.conf.j2
+++ b/roles/cfg_openwrt/templates/common/nftables.conf.j2
@@ -11,8 +11,12 @@ network_ifname_map =
 #}
 {% set network_ifname_map = [] %}
 {% for wd in wireless_devices | default([]) %}
-  {% set wd_config = profile['devices'] | selectattr('radio', 'contains', wd['name']) | first %}
   {% set wd_ifaces = profile['ifaces'] | default([]) | selectattr('radio', 'contains', wd['name']) %}
+  {% if 'devices' in profile %}
+    {% set wd_config = profile['devices'] | default([]) | selectattr('radio', 'contains', wd['name']) | first %}
+  {% else %}
+    {% set wd_config = {} %}
+  {% endif %}  {% set wd_ifaces = profile['ifaces'] | default([]) | selectattr('radio', 'contains', wd['name']) %}
   {% if not wd_config.get('disabled') %}
     {% for iface in wd_ifaces %}
       {% set ifname = wd['ifname_hint'] + '-' + iface['ifname_hint']|default('if' + loop.index0|string) %}


### PR DESCRIPTION
The `legacy_rates` and `country` options are declared in a boilerplate way all over the tree. Create sane defaults and remove the unnecessary declarations from the tree.