### PR TITLE
treewide: remove mt76 debugging

### DIFF
--- a/locations/huette.yml
+++ b/locations/huette.yml
@@ -17,10 +17,7 @@ hosts:
     model: "zyxel_nwa55axe"
     wireless_profile: freifunk_default
     openwrt_version: snapshot
-    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
     log_size: 1024
-    host__rclocal__to_merge:
-      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
     ssl__packages__to_merge: []
 
 ipv6_prefix: '2001:bf7:830:2600::/56'

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -41,9 +41,6 @@ hosts:
     model: zyxel_nwa50ax
     openwrt_version: snapshot
     log_size: 1024
-    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
-    host__rclocal__to_merge:
-      - "echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm"
     ssl__packages__to_merge: []
 
 snmp_devices:

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -31,7 +31,6 @@ hosts:
     model: "cudy_x6-v1"
     wireless_profile: freifunk_default
     openwrt_version: snapshot
-    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
     log_size: 1024
     ssl__packages__to_merge: []
 
@@ -40,10 +39,7 @@ hosts:
     model: "zyxel_nwa55axe"
     wireless_profile: kiehlufer5g
     openwrt_version: snapshot
-    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
     log_size: 1024
-    host__rclocal__to_merge:
-      - "echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm"
     ssl__packages__to_merge: []
 
   - hostname: kiehlufer-nf-wbp1

--- a/locations/kub.yml
+++ b/locations/kub.yml
@@ -20,12 +20,8 @@ hosts:
     role: ap
     model: "cudy_x6-v1"
     openwrt_version: snapshot
-    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
     log_size: 1024
     host__rclocal__to_merge:
-      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
-      - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
-      - ''
       - '#'
       - '# This script adjusts the configuration of vlans. This is especially'
       - '# useful with uswflex and custom port configs'

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -13,6 +13,8 @@ hosts:
   - hostname: radbahn-core
     role: corerouter
     model: ubnt_usw-flex
+    openwrt_version: snapshot
+    ssl__packages__to_merge: []
 
   - hostname: radbahn-o-nf
     role: ap

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -20,11 +20,7 @@ hosts:
     wireless_profile: freifunk_default
     dhcp_no_ping: false
     openwrt_version: snapshot
-    # imagebuilder: /home/user/w/ff/bbb-configs/openwrt-imagebuilder-ramips-mt7621.Linux-x86_64.tar.zst
     log_size: 1024
-    host__rclocal__to_merge:
-      - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
-      - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
     ssl__packages__to_merge: []
 
 # 10.248.13.0/24


### PR DESCRIPTION
(Except on radbahn-w-nf and radbahn-o-nf, which I'll monitor for a while longer.)