### PR TITLE
wireless: Revert whitespace change in previous template change

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/wireless.j2
+++ b/roles/cfg_openwrt/templates/common/config/wireless.j2
@@ -57,7 +57,7 @@ config wifi-device '{{ wd_id }}'
   {% if 'legacy_rates' in wd_config %}
 	option legacy_rates '{{ wd_config['legacy_rates']|int }}'
   {% else %}
-    option legacy_rates '0'
+	option legacy_rates '0'
   {% endif %}
   {% if 'disabled' in wd_config %}
 	option disabled '{{ wd_config['disabled']|int }}'


### PR DESCRIPTION
Fix whitespace change introduced in https://github.com/freifunk-berlin/bbb-configs/pull/1013
