### PR TITLE
imageprofile: return to MbedTLS

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -27,15 +27,6 @@ all__packages__to_merge:
   - -ppp
   - -ppp-mod-pppoe
 
-ssl__packages__to_merge:
-  - -wpad-basic
-  - -wpad-basic-mbedtls
-  - -wpad-basic-wolfssl
-  - -libustream-mbedtls
-  - libustream-wolfssl
-  - hostapd-wolfssl
-  - px5g-wolfssl
-
 all_luci_base__packages__to_merge:
   - libiwinfo-lua
   - luci-mod-admin-full

--- a/group_vars/target_ipq40xx_generic
+++ b/group_vars/target_ipq40xx_generic
@@ -1,21 +1,5 @@
 ---
 
-target__packages__to_merge:
-  # Work around ipq40xx ethernet instabilities
-  - naywatch
-  # Use OpenSSL because WolfSSL and MbedTLS are broken on ipq40xx
-  - -wpad-basic
-  - -wpad-basic-mbedtls
-  - -wpad-basic-wolfssl
-  - -hostapd-wolfssl
-  - -hostapd-mbedtls
-  - -libustream-mbedtls
-  - -libustream-wolfssl
-  - -px5g-mbedtls
-  - -px5g-wolfssl
-  - libustream-openssl
-  - hostapd-openssl
-
 multicore: true
 
 sysfs_overrides:

--- a/locations/huette.yml
+++ b/locations/huette.yml
@@ -18,7 +18,6 @@ hosts:
     wireless_profile: freifunk_default
     openwrt_version: snapshot
     log_size: 1024
-    ssl__packages__to_merge: []
 
 ipv6_prefix: '2001:bf7:830:2600::/56'
 

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -41,7 +41,6 @@ hosts:
     model: zyxel_nwa50ax
     openwrt_version: snapshot
     log_size: 1024
-    ssl__packages__to_merge: []
 
 snmp_devices:
 

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -32,7 +32,6 @@ hosts:
     wireless_profile: freifunk_default
     openwrt_version: snapshot
     log_size: 1024
-    ssl__packages__to_merge: []
 
   - hostname: kiehlufer-huette
     role: ap
@@ -40,7 +39,6 @@ hosts:
     wireless_profile: kiehlufer5g
     openwrt_version: snapshot
     log_size: 1024
-    ssl__packages__to_merge: []
 
   - hostname: kiehlufer-nf-wbp1
     role: ap

--- a/locations/kub.yml
+++ b/locations/kub.yml
@@ -69,7 +69,6 @@ hosts:
       - 'uci commit network'
       - 'sync'
       - 'reload_config'
-    ssl__packages__to_merge: []
 
 snmp_devices:
   - hostname: kub-simeon

--- a/locations/radbahn.yml
+++ b/locations/radbahn.yml
@@ -14,7 +14,6 @@ hosts:
     role: corerouter
     model: ubnt_usw-flex
     openwrt_version: snapshot
-    ssl__packages__to_merge: []
 
   - hostname: radbahn-o-nf
     role: ap
@@ -26,7 +25,6 @@ hosts:
     host__rclocal__to_merge:
       - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
       - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
-    ssl__packages__to_merge: []
 
   - hostname: radbahn-w-nf
     role: ap
@@ -38,7 +36,6 @@ hosts:
     host__rclocal__to_merge:
       - 'echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/fw_debug_wm'
       - 'echo 1 > /sys/kernel/debug/ieee80211/phy1/mt76/fw_debug_wm'
-    ssl__packages__to_merge: []
 
 snmp_devices:
 

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -21,7 +21,6 @@ hosts:
     dhcp_no_ping: false
     openwrt_version: snapshot
     log_size: 1024
-    ssl__packages__to_merge: []
 
 # 10.248.13.0/24
 # 10.248.13.0/29 - mgmt


### PR DESCRIPTION
There was a time when MbedTLS was already the default in OpenWrt, but didn't yet support everything that we needed.

It does now. I have been testing it on a few busy locations for a few months.