### PR TITLE
walde: fix ip in snmp_section for walde-emma

### DIFF
--- a/locations/walde.yml
+++ b/locations/walde.yml
@@ -16,7 +16,7 @@ hosts:
 
 snmp_devices:
   - hostname: walde-emma
-    address: 10.31.92.1
+    address: 10.31.92.2
     snmp_profile: airos_8
 
 


### PR DESCRIPTION
Note: The mgmt-IP is currently set to 192.168.x.x for `walde-emma`