### PR TITLE
collectd: only load iwinfo plugin on non low_mem or _flash devices

### DIFF
--- a/roles/cfg_openwrt/templates/common/collectd/conf.d/basic.conf.j2
+++ b/roles/cfg_openwrt/templates/common/collectd/conf.d/basic.conf.j2
@@ -33,7 +33,7 @@ LoadPlugin olsrd
 </Plugin>
 {% endif %}
 
-{% if wireless_devices is defined and wireless_profile != 'disable' %}
+{% if wireless_devices is defined and wireless_profile != 'disable' and low_mem is not true | default (true) and low_flash is not true | default (true) %}
 LoadPlugin iwinfo
 {% endif %}
 


### PR DESCRIPTION
This fixes #1030