### PR TITLE
imageprofile: fix TLS certificate generation

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -32,6 +32,7 @@ all_luci_base__packages__to_merge:
   - luci-mod-admin-full
   - luci-proto-ipv6
   - luci-theme-bootstrap
+  - luci-ssl
   - rpcd-mod-rrdns
   - uhttpd
   - uhttpd-mod-ubus


### PR DESCRIPTION
We removed px5g in 4f29940 without making sure there's another variant of it installed. Pull in the default via luci-ssl.