### PR TITLE
imageprofile: roll back luci-ssl

### DIFF
--- a/group_vars/all/imageprofile.yml
+++ b/group_vars/all/imageprofile.yml
@@ -32,7 +32,6 @@ all_luci_base__packages__to_merge:
   - luci-mod-admin-full
   - luci-proto-ipv6
   - luci-theme-bootstrap
-  - luci-ssl
   - rpcd-mod-rrdns
   - uhttpd
   - uhttpd-mod-ubus


### PR DESCRIPTION
With luci-ssl enabled the core-router images worked just fine, the ap images however not. APs became unreachable after flashing. I did not have the time to debug this as it would require setting up a VM to look what's actually going on.