### PR TITLE
version: add 24.10-SNAPSHOT

### DIFF
--- a/group_vars/version_24_10_snapshot.yml
+++ b/group_vars/version_24_10_snapshot.yml
@@ -1,0 +1,4 @@
+---
+feed_version: 1.5.0-snapshot
+
+imagebuilder_filename: "openwrt-imagebuilder-24.10-SNAPSHOT-{{ target | replace('/','-') }}.Linux-x86_64.tar.zst"

--- a/locations/pktpls.yml
+++ b/locations/pktpls.yml
@@ -11,7 +11,7 @@ hosts:
   - hostname: pktpls-core
     role: corerouter
     model: "x86-64"
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
 
 # feed: "src/gz openwrt_falter file:///home/user/w/ff/falter-packages/out/main/x86_64/falter"
 # imagebuilder_disable_signature_check: true


### PR DESCRIPTION
The falter 1.5.0-snapshot package feed is already built - we can start testing