### PR TITLE
birdc: metrics penalty for 2GHz adhoc

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -53,5 +53,6 @@ mesh_metric_default_in: 512
 # Default mesh metric in inbound direction (rxcost) for tunnels
 mesh_metric_tunnel_in: 512
 
-# Default mesh metric in inbound direction (rxcost) for adhoc like interfaces
-mesh_metric_adhoc_in: 2048
+# Default mesh metrics in inbound direction (rxcost) for adhoc like interfaces
+mesh_metric_adhoc_11a_standard: 2024
+mesh_metric_adhoc_11g_standard: 2536

--- a/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/corerouter/bird.conf.j2
@@ -40,8 +40,9 @@ protocol babel {
 	};
 
 	# Mesh interfaces
+{# metrics for 2 GHz adhoc get a penalty over 5 GHz adhoc so 5 GHz is preferred #}
 {% for nw in networks | selectattr('role', 'equalto', 'mesh') %}
-  {% set default_mesh_metric = mesh_metric_adhoc_in if 'mesh_ap' else mesh_metric_default_in %}
+  {% set default_mesh_metric = hostvars[inventory_hostname].get('mesh_metric_adhoc_' ~ nw.get('mesh_radio'), mesh_metric_default_in) %} 
 	interface "{{ libnetwork.getIfname(nw) }}" {
 		type wireless;
 		rxcost {{ nw.get('mesh_metric', default_mesh_metric) }};


### PR DESCRIPTION
this makes the metric of 2GHz mesh links worse than 5GHz mesh links by adding the default metric.

In addition to this we need to adjust metrics at various locations where 802.11s links have metrics manually set below 2048 as the new default of 2048 for 802.11s changes routing at various locations.