### PR TITLE
Ansible: enable profiler to show timestamps while execution

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,7 @@ inventory = inventory/base_inventory, inventory/keyed_groups_stage_1.config, inv
 interpreter_python = auto_silent
 stdout_callback = debug
 jinja2_extensions = jinja2.ext.do
+callbacks_enabled = ansible.posix.profile_tasks, ansible.posix.timer
 
 #needed for software upgrade
 [persistent_connection]


### PR DESCRIPTION
This change enables  ansible to show the timestamp per Task.

```
(venv) spolack@fedora:~/git/bbb-configs$ ansible-playbook -l role_gateway -t config play.yml 

PLAY [Running bbb-configs] **************************************************************************************************************************************************************************************************************************************************************************************************

TASK [cfg_openwrt : Include tasks for merging variables] ********************************************************************************************************************************************************************************************************************************************************************
Sonntag 10 November 2024  18:40:55 +0100 (0:00:00.016)       0:00:00.016 ****** 
included: /home/spolack/git/bbb-configs/roles/cfg_openwrt/tasks/merge_vars.yml for ak36-gw, l105-gw, ohlauer-gw, saarbruecker-gw, strom-gw

TASK [cfg_openwrt : Merge packages variable] ********************************************************************************************************************************************************************************************************************************************************************************
Sonntag 10 November 2024  18:40:55 +0100 (0:00:00.035)       0:00:00.051 ****** 
ok: [ak36-gw]
ok: [l105-gw]
ok: [ohlauer-gw]
ok: [saarbruecker-gw]
ok: [strom-gw]

TASK [cfg_openwrt : Merge disabled_services variable] ***********************************************************************************************************************************************************************************************************************************************************************
Sonntag 10 November 2024  18:40:55 +0100 (0:00:00.029)       0:00:00.081 ****** 
ok: [ak36-gw]
ok: [l105-gw]
ok: [ohlauer-gw]
ok: [saarbruecker-gw]
ok: [strom-gw]

TASK [cfg_openwrt : Merge wireless_profiles variable] ***********************************************************************************************************************************************************************************************************************************************************************
Sonntag 10 November 2024  18:40:55 +0100 (0:00:00.036)       0:00:00.117 ****** 
ok: [ak36-gw]
ok: [l105-gw]
ok: [ohlauer-gw]
ok: [saarbruecker-gw]
ok: [strom-gw]
```