### PR TITLE
metrics: adjustments and removal of unnecessary settings

### DIFF
--- a/locations/bilgi.yml
+++ b/locations/bilgi.yml
@@ -32,7 +32,6 @@ networks:
     mesh_ap: bilgi-core
     mesh_radio: 11a_standard
     mesh_iface: mesh
-    mesh_metric: 1024
 
   - vid: 21
     role: mesh
@@ -42,7 +41,6 @@ networks:
     mesh_ap: bilgi-core
     mesh_radio: 11g_standard
     mesh_iface: mesh
-    mesh_metric: 1024
 
   - vid: 40
     role: dhcp

--- a/locations/chris.yml
+++ b/locations/chris.yml
@@ -105,7 +105,6 @@ networks:
     name: 11s_n_2ghz
     prefix: 10.230.18.167/32
     ipv6_subprefix: -7
-    mesh_metric: 1024
     mesh_ap: chris-n-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -115,7 +114,6 @@ networks:
     name: 11s_o_2ghz
     prefix: 10.230.18.169/32
     ipv6_subprefix: -9
-    mesh_metric: 1024
     mesh_ap: chris-o-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -125,7 +123,6 @@ networks:
     name: 11s_s_2ghz
     prefix: 10.230.18.170/32
     ipv6_subprefix: -10
-    mesh_metric: 1024
     mesh_ap: chris-s-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -135,7 +132,6 @@ networks:
     name: 11s_w_2ghz
     prefix: 10.230.18.171/32
     ipv6_subprefix: -11
-    mesh_metric: 1024
     mesh_ap: chris-w-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -28,7 +28,6 @@ networks:
     name: mesh_scharni
     prefix: 10.31.52.237/32
     ipv6_subprefix: -3
-    mesh_metric: 2048
     mesh_ap: colbe15-ap1
     mesh_radio: 11a_standard
     mesh_iface: mesh

--- a/locations/cralle.yml
+++ b/locations/cralle.yml
@@ -65,8 +65,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.31.113.89/32
     ipv6_subprefix: -2
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: cralle-core
     mesh_radio: 11g_standard

--- a/locations/dragonkiez-adlerhalle.yml
+++ b/locations/dragonkiez-adlerhalle.yml
@@ -62,8 +62,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.31.23.32/32
     ipv6_subprefix: -3
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: dragonkiez-adlerhalle
     mesh_radio: 11g_standard

--- a/locations/dragonkiez-dorfplatz.yml
+++ b/locations/dragonkiez-dorfplatz.yml
@@ -69,8 +69,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.31.28.245/32
     ipv6_subprefix: -3
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: dragonkiez-dorfplatz
     mesh_radio: 11g_standard
@@ -92,8 +91,7 @@ networks:
     name: mesh2_ap1
     prefix: 10.31.28.247/32
     ipv6_subprefix: -5
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: dragonkiez-dorfplatz-ap1
     mesh_radio: 11g_standard

--- a/locations/dragonkiez-kiezraum.yml
+++ b/locations/dragonkiez-kiezraum.yml
@@ -68,8 +68,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.31.92.242/32
     ipv6_subprefix: -3
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: dragonkiez-kiezraum
     mesh_radio: 11g_standard

--- a/locations/dragonkiez-rathausblock-miami.yml
+++ b/locations/dragonkiez-rathausblock-miami.yml
@@ -74,8 +74,7 @@ networks:
     name: mesh2_ap1
     prefix: 10.31.30.25/32
     ipv6_subprefix: -3
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: dragonkiez-rathausblock-miami-ap1
     mesh_radio: 11g_standard
@@ -97,8 +96,7 @@ networks:
     name: mesh2_ap2
     prefix: 10.31.30.27/32
     ipv6_subprefix: -5
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: dragonkiez-rathausblock-miami-ap2
     mesh_radio: 11g_standard

--- a/locations/e16outdoor.yml
+++ b/locations/e16outdoor.yml
@@ -77,8 +77,7 @@ networks:
     name: mesh_11s_2ghz
     prefix: 10.31.142.33/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: e16outdoor-core
     mesh_radio: 11g_standard

--- a/locations/eberswalder7.yml
+++ b/locations/eberswalder7.yml
@@ -55,8 +55,7 @@ networks:
     name: mesh_11s_2g
     prefix: 10.31.238.210/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: eberswalder7-core
     mesh_radio: 11g_standard

--- a/locations/elsekiehl.yml
+++ b/locations/elsekiehl.yml
@@ -66,8 +66,7 @@ networks:
     name: mesh_11s_2ghz
     prefix: 10.31.179.33/32
     ipv6_subprefix: -2
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: elsekiehl-core
     mesh_radio: 11g_standard

--- a/locations/fffw-lebenshilfe.yml
+++ b/locations/fffw-lebenshilfe.yml
@@ -56,7 +56,6 @@ networks:
     name: mesh_nno
     prefix: 10.30.96.43/32
     ipv6_subprefix: -1
-    mesh_metric: 1024
     mesh_ap: fffw-lebenshilfe-nno-ap-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -66,7 +65,6 @@ networks:
     name: mesh_nw
     prefix: 10.30.96.44/32
     ipv6_subprefix: -2
-    mesh_metric: 1024
     mesh_ap: fffw-lebenshilfe-nw-ap-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -76,7 +74,6 @@ networks:
     name: mesh_sso
     prefix: 10.30.96.45/32
     ipv6_subprefix: -3
-    mesh_metric: 1024
     mesh_ap: fffw-lebenshilfe-sso-ap-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -86,7 +83,6 @@ networks:
     name: mesh_ono
     prefix: 10.30.96.46/32
     ipv6_subprefix: -4
-    mesh_metric: 1024
     mesh_ap: fffw-lebenshilfe-ono-ap-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh

--- a/locations/funkigel.yml
+++ b/locations/funkigel.yml
@@ -64,8 +64,7 @@ networks:
     name: mesh_2g
     prefix: 10.248.9.210/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2.4 GHz worse than 5 GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2.4 GHz worse than 5 GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: funkigel
     mesh_radio: 11g_standard

--- a/locations/gruni73.yml
+++ b/locations/gruni73.yml
@@ -98,7 +98,6 @@ networks:
     name: mesh_11s_o5
     prefix: 10.31.156.40/32
     ipv6_subprefix: -6
-    mesh_metric: 1024
     mesh_ap: gruni73-nf-o-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -109,7 +108,6 @@ networks:
     name: mesh_11s_s5
     prefix: 10.31.156.41/32
     ipv6_subprefix: -7
-    mesh_metric: 1024
     mesh_ap: gruni73-nf-s-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -120,7 +118,6 @@ networks:
     name: mesh_11s_w5
     prefix: 10.31.156.42/32
     ipv6_subprefix: -8
-    mesh_metric: 1024
     mesh_ap: gruni73-nf-w-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh

--- a/locations/habersaath.yml
+++ b/locations/habersaath.yml
@@ -103,7 +103,6 @@ networks:
     mesh_ap: habersaath-w-nf-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh
-    mesh_metric: 1024
     mesh_metric_lqm:
       - default 0.12   # Penalty so local uplink is preferred
 

--- a/locations/hirschhof.yml
+++ b/locations/hirschhof.yml
@@ -32,8 +32,7 @@ networks:
     name: mesh_5ghz
     prefix: 10.31.159.128/32
     ipv6_subprefix: -20
-    # make mesh_metric(s) for 2GHz omni worse than 2GHz directional
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz omni worse than 2GHz directional
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: hirschhof-core
     mesh_radio: 11a_standard
@@ -45,8 +44,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.31.159.129/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz omni worse than 5GHz omni
-    mesh_metric: 2048
+    # make mesh_metric for 2GHz omni worse than 5GHz omni
     mesh_metric_lqm: ['default 0.6']
     mesh_ap: hirschhof-core
     mesh_radio: 11g_standard
@@ -58,7 +56,7 @@ networks:
     name: mesh_k12
     prefix: 10.31.159.130/32
     ipv6_subprefix: -22
-    # adjust mesh_metric(s) to prefer this route
+    # adjust mesh_metric to prefer this route
     mesh_metric: 512
     mesh_ap: hirschhof-k12
     mesh_radio: 11g_standard

--- a/locations/huette.yml
+++ b/locations/huette.yml
@@ -44,8 +44,7 @@ networks:
   #   name: mesh_11s_2ghz
   #   prefix: 10.31.114.2/32
   #   ipv6_subprefix: -21
-  #   # make mesh_metric(s) for 2GHz worse than 5GHz
-  #   mesh_metric: 1024
+  #   # make mesh_metric for 2GHz worse than 5GHz
   #   mesh_metric_lqm: ['default 0.8']
   #   mesh_ap: huette-core
   #   mesh_radio: 11g_standard

--- a/locations/jup.yml
+++ b/locations/jup.yml
@@ -65,8 +65,8 @@ networks:
     name: mesh_bht
     prefix: 10.31.147.128/32
     ipv6_subprefix: -1
-    mesh_metric: 2048
-    mesh_metric_lqm: ['default 0.25']
+    mesh_metric: 1024
+    mesh_metric_lqm: ['default 0.5']
     ptp: true
 
   - vid: 11

--- a/locations/k11.yml
+++ b/locations/k11.yml
@@ -42,8 +42,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.31.185.129/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k11-core
     mesh_radio: 11g_standard

--- a/locations/k12-h1-h3n.yml
+++ b/locations/k12-h1-h3n.yml
@@ -41,8 +41,7 @@ networks:
     name: mesh_core_2g
     prefix: 10.248.19.241/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h1-h3n
     mesh_radio: 11g_standard

--- a/locations/k12-h1.yml
+++ b/locations/k12-h1.yml
@@ -42,8 +42,7 @@ networks:
     name: mesh_core_2g
     prefix: 10.31.226.146/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h1-core
     mesh_radio: 11g_standard
@@ -55,7 +54,7 @@ networks:
     name: mesh_lan
     prefix: 10.31.226.147/32
     ipv6_subprefix: -30
-    # adjust mesh_metric(s) to prefer this
+    # adjust mesh_metric to prefer this
     mesh_metric: 128
 
   # DHCP with filtering and isolation

--- a/locations/k12-h2.yml
+++ b/locations/k12-h2.yml
@@ -71,8 +71,7 @@ networks:
     name: mesh_core_2g
     prefix: 10.31.158.130/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h2-core
     mesh_radio: 11g_standard
@@ -94,8 +93,7 @@ networks:
     name: mesh_h1s_2g
     prefix: 10.31.158.132/32
     ipv6_subprefix: -23
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h2-h1s
     mesh_radio: 11g_standard
@@ -107,7 +105,7 @@ networks:
     name: mesh_cpe
     prefix: 10.31.158.133/32
     ipv6_subprefix: -24
-    # adjust mesh_metric(s) to prefer this route
+    # adjust mesh_metric to prefer this route
     mesh_metric: 256
     mesh_ap: k12-h2-cpe
     mesh_radio: 11a_standard
@@ -119,7 +117,7 @@ networks:
     name: mesh_lan
     prefix: 10.31.226.134/32
     ipv6_subprefix: -30
-    # adjust mesh_metric(s) to prefer this route
+    # adjust mesh_metric to prefer this route
     mesh_metric: 128
 
   # DHCP

--- a/locations/k12-h3-v0s.yml
+++ b/locations/k12-h3-v0s.yml
@@ -42,8 +42,7 @@ networks:
     name: mesh_core_2g
     prefix: 10.31.227.145/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h3-v0s
     mesh_radio: 11g_standard

--- a/locations/k12-h3-v2s.yml
+++ b/locations/k12-h3-v2s.yml
@@ -42,8 +42,7 @@ networks:
     name: mesh_core_2g
     prefix: 10.248.19.145/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h3-v2s
     mesh_radio: 11g_standard

--- a/locations/k12-h3.yml
+++ b/locations/k12-h3.yml
@@ -48,8 +48,7 @@ networks:
     name: mesh_core_2g
     prefix: 10.31.226.210/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h3-core
     mesh_radio: 11g_standard
@@ -71,8 +70,7 @@ networks:
     name: mesh_h3n_2g
     prefix: 10.31.226.212/32
     ipv6_subprefix: -23
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h3-h3n
     mesh_radio: 11g_standard
@@ -94,8 +92,7 @@ networks:
   #   name: mesh_v2s_2g
   #   prefix: 10.31.226.214/32
   #   ipv6_subprefix: -25
-  #   # make mesh_metric(s) for 2GHz worse than 5GHz
-  #   mesh_metric: 1024
+  #   # make mesh_metric for 2GHz worse than 5GHz
   #   mesh_metric_lqm: ['default 0.8']
   #   mesh_ap: k12-h3-v2s
   #   mesh_radio: 11g_standard

--- a/locations/k12-h4.yml
+++ b/locations/k12-h4.yml
@@ -63,6 +63,8 @@ networks:
     name: mesh_hirsch
     prefix: 10.31.157.162/32
     ipv6_subprefix: -22
+    # prefer this link towards Hirschhof
+    mesh_metric: 512
     mesh_ap: k12-h4-hirschhof
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -83,8 +85,7 @@ networks:
     name: mesh_h0s_2g
     prefix: 10.31.157.164/32
     ipv6_subprefix: -24
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: k12-h4-h0s
     mesh_radio: 11g_standard

--- a/locations/k9.yml
+++ b/locations/k9.yml
@@ -72,7 +72,7 @@ networks:
     name: mesh_k9int
     prefix: 10.31.9.240/28
     ipv6_subprefix: -20
-    mesh_metric: 64
+    mesh_metric: 128
     mesh_metric_lqm: ['default 0.2']
     # Ignore Uplink one Hop away / requires 0.2 LQM
     assignments:
@@ -94,8 +94,7 @@ networks:
     name: mesh_2g
     prefix: 10.31.9.228/32
     ipv6_subprefix: -22
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: k9-core
     mesh_radio: 11g_standard

--- a/locations/kiehl71.yml
+++ b/locations/kiehl71.yml
@@ -66,8 +66,7 @@ networks:
     name: mesh_11s_2ghz
     prefix: 10.31.178.225/32
     ipv6_subprefix: -2
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: kiehl71-core
     mesh_radio: 11g_standard

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -120,7 +120,6 @@ networks:
     name: mesh_nf_wbp1
     prefix: 10.31.151.115/32
     ipv6_subprefix: -4
-    mesh_metric: 2048
     mesh_ap: kiehlufer-nf-wbp1
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -129,7 +128,6 @@ networks:
     name: mesh_nf_wbp2
     prefix: 10.31.151.116/32
     ipv6_subprefix: -5
-    mesh_metric: 2048
     mesh_ap: kiehlufer-nf-wbp2
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -138,7 +136,6 @@ networks:
     name: mesh_nf_wbp3
     prefix: 10.31.151.117/32
     ipv6_subprefix: -6
-    mesh_metric: 2048
     mesh_ap: kiehlufer-nf-wbp3
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -148,7 +145,6 @@ networks:
     name: mesh_huet_5g
     prefix: 10.31.151.118/32
     ipv6_subprefix: -7
-    mesh_metric: 2048
     mesh_ap: kiehlufer-huette
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -157,7 +153,6 @@ networks:
     name: mesh_nf_wbp4
     prefix: 10.31.151.119/32
     ipv6_subprefix: -8
-    mesh_metric: 2048
     mesh_ap: kiehlufer-nf-wbp4
     mesh_radio: 11a_standard
     mesh_iface: mesh

--- a/locations/knallt-m42.yml
+++ b/locations/knallt-m42.yml
@@ -50,8 +50,7 @@ networks:
     name: mesh_2ghz
     prefix: 10.248.0.99/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: knallt-m42-core
     mesh_radio: 11g_standard

--- a/locations/kotti.yml
+++ b/locations/kotti.yml
@@ -52,8 +52,7 @@ networks:
     name: mesh_2g
     prefix: 10.31.167.218/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: kotti-core
     mesh_radio: 11g_standard

--- a/locations/kts13.yml
+++ b/locations/kts13.yml
@@ -43,7 +43,6 @@ networks:
     name: mesh_ap1
     prefix: '10.31.166.194/32'
     ipv6_subprefix: -2
-    mesh_metric: 1024
     mesh_ap: kts13-ap1
     mesh_radio: 11a_standard
     mesh_iface: mesh

--- a/locations/mahalle.yml
+++ b/locations/mahalle.yml
@@ -42,7 +42,6 @@ networks:
     mesh_ap: mahalle-nf-w
     mesh_radio: 11a_standard
     mesh_iface: mesh
-    mesh_metric: 1024
 
   - vid: 21
     role: mesh
@@ -52,7 +51,6 @@ networks:
     mesh_ap: mahalle-nf-o
     mesh_radio: 11a_standard
     mesh_iface: mesh
-    mesh_metric: 1024
 
   - vid: 40
     role: dhcp

--- a/locations/mlk-nk.yml
+++ b/locations/mlk-nk.yml
@@ -53,9 +53,7 @@ networks:
     name: mesh_nno_5
     prefix: 10.31.69.33/32
     ipv6_subprefix: -11
-    mesh_metric: 1024
     mesh_metric_lqm: ['default 0.6']
-    ptp: true
 
   # Nanostation M5 - Airos 6 - Orientation Sonnenallee
   - vid: 12
@@ -63,9 +61,7 @@ networks:
     name: mesh_so_5
     prefix: 10.31.69.34/32
     ipv6_subprefix: -12
-    mesh_metric: 1024
     mesh_metric_lqm: ['default 0.7']
-    ptp: true
 
   # 802.11s mesh links (VID 20-29)
   # 802.11s mesh nf - SXTsq5ac - Orientation Rhnk
@@ -84,7 +80,6 @@ networks:
     name: mesh_nf_wbp2
     prefix: 10.31.69.36/32
     ipv6_subprefix: -21
-    mesh_metric: 2048
     mesh_ap: mlk-nk-nf-wbp2
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -95,7 +90,6 @@ networks:
     name: mesh_nf_wbp3
     prefix: 10.31.69.37/32
     ipv6_subprefix: -22
-    mesh_metric: 2048
     mesh_ap: mlk-nk-nf-wbp3
     mesh_radio: 11g_standard
     mesh_iface: mesh

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -77,8 +77,7 @@ networks:
     name: mesh_2g_core
     prefix: 10.31.215.35/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: noki-core
     mesh_radio: 11g_standard
@@ -100,8 +99,7 @@ networks:
     name: mesh_2g_ap
     prefix: 10.31.215.37/32
     ipv6_subprefix: -23
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: noki-ap
     mesh_radio: 11g_standard

--- a/locations/perle.yml
+++ b/locations/perle.yml
@@ -58,7 +58,6 @@ networks:
     name: mesh_2g
     prefix: 10.31.205.138/32
     ipv6_subprefix: -21
-    mesh_metric: 1024
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: perle-core
     mesh_radio: 11g_standard

--- a/locations/rev99.yml
+++ b/locations/rev99.yml
@@ -52,8 +52,7 @@ networks:
     name: mesh_2g
     prefix: 10.31.214.138/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: rev99-core
     mesh_radio: 11g_standard

--- a/locations/rio.yml
+++ b/locations/rio.yml
@@ -64,7 +64,6 @@ networks:
     name: mesh_rio
     prefix: 10.31.134.18/32
     ipv6_subprefix: -3
-    mesh_metric: 2048
     mesh_ap: rio-sxt
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -74,7 +73,6 @@ networks:
     name: mesh_ubnt
     prefix: 10.31.134.19/32
     ipv6_subprefix: -4
-    mesh_metric: 2048
     mesh_ap: rio-ubnt
     mesh_radio: 11a_standard
     mesh_iface: mesh

--- a/locations/scharni.yml
+++ b/locations/scharni.yml
@@ -65,7 +65,6 @@ networks:
     name: mesh_zwingli
     prefix: 10.31.252.193/32
     ipv6_subprefix: -3
-    mesh_metric: 512
     ptp: true
 
   - vid: 20
@@ -73,7 +72,6 @@ networks:
     name: mesh_ap3
     prefix: 10.31.252.194/32
     ipv6_subprefix: -4
-    mesh_metric: 2048
     mesh_ap: scharni-ap3
     mesh_radio: 11a_standard
     mesh_iface: mesh

--- a/locations/segen.yml
+++ b/locations/segen.yml
@@ -223,7 +223,6 @@ networks:
     name: mesh_11s_n2
     prefix: 10.31.6.72/32
     ipv6_subprefix: -9
-    mesh_metric: 2048
     mesh_metric_lqm: ['default 0.4']
     mesh_ap: segen-n-nf-2ghz
     mesh_radio: 11g_standard
@@ -234,7 +233,6 @@ networks:
     name: mesh_11s_o2
     prefix: 10.31.6.73/32
     ipv6_subprefix: -10
-    mesh_metric: 2048
     mesh_metric_lqm: ['default 0.4']
     mesh_ap: segen-o-nf-2ghz
     mesh_radio: 11g_standard
@@ -245,7 +243,6 @@ networks:
     name: mesh_11s_s2
     prefix: 10.31.6.74/32
     ipv6_subprefix: -11
-    mesh_metric: 2048
     mesh_metric_lqm: ['default 0.4']
     mesh_ap: segen-s-nf-2ghz
     mesh_radio: 11g_standard
@@ -256,7 +253,6 @@ networks:
     name: mesh_11s_w2
     prefix: 10.31.6.75/32
     ipv6_subprefix: -12
-    mesh_metric: 2048
     mesh_metric_lqm: ['default 0.4']
     mesh_ap: segen-w-nf-2ghz
     mesh_radio: 11g_standard

--- a/locations/spitta13.yml
+++ b/locations/spitta13.yml
@@ -88,7 +88,6 @@ networks:
     mesh_radio: 11g_standard
     mesh_iface: mesh
     mesh_metric_lqm: ['default 0.3']  # prefer 5 GHz mesh
-    mesh_metric: 1024
 
   - vid: 21
     role: mesh

--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -46,8 +46,7 @@ networks:
     name: mesh_2g
     prefix: 10.248.17.17/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.8']
     mesh_ap: tempelwg-core
     mesh_radio: 11g_standard

--- a/locations/vaterhaus.yml
+++ b/locations/vaterhaus.yml
@@ -137,7 +137,6 @@ networks:
     name: mesh_11s_no
     prefix: 10.230.192.230/32
     ipv6_subprefix: -7
-    mesh_metric: 2048
     mesh_ap: vaterhaus-n-nf-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -79,8 +79,7 @@ networks:
     name: mesh_2g
     prefix: 10.31.212.36/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: w38b-core
     mesh_radio: 11g_standard
@@ -102,8 +101,7 @@ networks:
     name: mesh_ap1_2g
     prefix: 10.31.212.38/32
     ipv6_subprefix: -23
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: w38b-ap1
     mesh_radio: 11g_standard
@@ -116,7 +114,7 @@ networks:
     prefix: 10.31.212.39/32
     ipv6_subprefix: -30
     # adjust mesh_metric(s) to prefer other links
-    mesh_metric: 2048
+    mesh_metric: 4096
     mesh_metric_lqm: ['default 0.25']
 
   # DHCP with filtering and isolation

--- a/locations/weidenbaum.yml
+++ b/locations/weidenbaum.yml
@@ -54,8 +54,7 @@ networks:
     name: mesh_2g
     prefix: 10.31.204.148/32
     ipv6_subprefix: -21
-    # make mesh_metric(s) for 2GHz worse than 5GHz
-    mesh_metric: 1024
+    # make mesh_metric for 2GHz worse than 5GHz
     mesh_metric_lqm: ['default 0.5']
     mesh_ap: weidenbaum-core
     mesh_radio: 11g_standard

--- a/locations/wilgu10.yml
+++ b/locations/wilgu10.yml
@@ -72,7 +72,6 @@ networks:
     name: mesh_east_2g
     prefix: 10.230.210.106/32
     ipv6_subprefix: -3
-    mesh_metric: 2048
     mesh_ap: wilgu10-east-nf-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh

--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -193,7 +193,6 @@ networks:
     name: mesh_11s_o2
     prefix: 10.31.115.42/32
     ipv6_subprefix: -11
-    mesh_metric: 1024
     mesh_ap: zwingli-ost-nf-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -205,7 +204,6 @@ networks:
     name: mesh_11s_w2
     prefix: 10.31.115.44/32
     ipv6_subprefix: -13
-    mesh_metric: 1024
     mesh_ap: zwingli-west-nf-2ghz
     mesh_radio: 11g_standard
     mesh_iface: mesh
@@ -219,7 +217,6 @@ networks:
     name: mesh_11s_n5
     prefix: 10.31.115.45/32
     ipv6_subprefix: -14
-    mesh_metric: 1024
     mesh_ap: zwingli-nord-nf-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -231,7 +228,6 @@ networks:
     name: mesh_11s_o5
     prefix: 10.31.115.46/32
     ipv6_subprefix: -15
-    mesh_metric: 1024
     mesh_ap: zwingli-ost-nf-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh
@@ -243,7 +239,6 @@ networks:
     name: mesh_11s_w5
     prefix: 10.31.115.48/32
     ipv6_subprefix: -17
-    mesh_metric: 1024
     mesh_ap: zwingli-west-nf-5ghz
     mesh_radio: 11a_standard
     mesh_iface: mesh


### PR DESCRIPTION
This PR adjusts metrics for a consistent routing and also removes unnecessary metrics settings where the setting was the default or the new defaults introduced by https://github.com/freifunk-berlin/bbb-configs/commit/3781df14d78fec529e1ec9867420c0866fba2065 should be used, that now generally prefer 5 GHz over 2.4 GHz 802.11s links.

This PR requires https://github.com/freifunk-berlin/falter-packages/pull/450 to be functional and merged and also #1087.