### PR TITLE
ap: prevent lockout when installing firewall later

### DIFF
--- a/roles/cfg_openwrt/templates/ap/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/ap/config/firewall.j2
@@ -1,0 +1,16 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+
+config defaults
+  option syn_flood '1'
+  option input 'ACCEPT'
+  option output 'ACCEPT'
+  option forward 'REJECT'
+  option drop_invalid '0'
+
+config zone 'zone_freifunk'
+  option name 'freifunk'
+  list network 'mgmt'
+
+config forwarding
+  option dest 'freifunk'
+  option src 'freifunk'


### PR DESCRIPTION
The AP image doesn't contain a firewall package or firewall settings. When installing the firewall later on, it loads default settings and locks us out of the device permanently.

Add a basic firewall config allowing mgmt access, just to prevent this improbable but unfortunate case.

(This happened at Teufelsberg the other week, people needed to go there to fix it.)