### PR TITLE
treewide: switch debugged hosts from snapshot to 24.10

### DIFF
--- a/locations/huette.yml
+++ b/locations/huette.yml
@@ -16,7 +16,7 @@ hosts:
     role: corerouter
     model: "zyxel_nwa55axe"
     wireless_profile: freifunk_default
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
     log_size: 1024
 
 ipv6_prefix: '2001:bf7:830:2600::/56'

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -39,7 +39,7 @@ hosts:
     role: ap
     wireless_profile: hway
     model: zyxel_nwa50ax
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
     log_size: 1024
 
 snmp_devices:

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -30,14 +30,14 @@ hosts:
     role: corerouter
     model: "cudy_x6-v1"
     wireless_profile: freifunk_default
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
     log_size: 1024
 
   - hostname: kiehlufer-huette
     role: ap
     model: "zyxel_nwa55axe"
     wireless_profile: kiehlufer5g
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
     log_size: 1024
 
   - hostname: kiehlufer-nf-wbp1

--- a/locations/kub.yml
+++ b/locations/kub.yml
@@ -17,7 +17,7 @@ hosts:
   - hostname: kub-ap1
     role: ap
     model: "cudy_x6-v1"
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
     log_size: 1024
 
 snmp_devices:

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -19,7 +19,7 @@ hosts:
     model: "cudy_x6-v1"
     wireless_profile: freifunk_default
     dhcp_no_ping: false
-    openwrt_version: snapshot
+    openwrt_version: 24.10-SNAPSHOT
     log_size: 1024
 
 # 10.248.13.0/24


### PR DESCRIPTION
These were running snapshot for mt76 debugging.

We can probably safely switch the whole device models (cudy_x6, zyxel_nwa50ax, zyxel_nwa55axe) to 24.10, but let's do that when 24.10 is closing in on release.