### PR TITLE
elsekiehl: remove unused tunspace setup

### DIFF
--- a/locations/elsekiehl.yml
+++ b/locations/elsekiehl.yml
@@ -84,23 +84,6 @@ networks:
     assignments:
       elsekiehl-core: 1
 
-  # WIREGUARD
-  - vid: 50
-    role: uplink
-    untagged: true
-
-  - role: tunnel
-    ifname: ts_wg0
-    mtu: 1280
-    prefix: 10.31.179.40/32
-    wireguard_port: 51820
-
-  - role: tunnel
-    ifname: ts_wg1
-    mtu: 1280
-    prefix: 10.31.179.41/32
-    wireguard_port: 51821
-
 # AP-id, wifi-channel, bandwidth, txpower
 location__channel_assignments_11a_standard__to_merge:
   elsekiehl-core: 36-20


### PR DESCRIPTION
It's never been used, and tunspace with an absent uplink currently produces a memory leak in bird2. Let's just remove tunspace here, it can be added back if/when the uplink materializes.