### PR TITLE
gateways: fix olsrd->babel soft migration

### DIFF
--- a/group_vars/role_gateway/imageprofile.yml
+++ b/group_vars/role_gateway/imageprofile.yml
@@ -7,7 +7,6 @@ role_uplink_gw__packages__to_merge:
   - collectd-mod-snmp6
   - olsrd
   - olsrd-mod-arprefresh
-  - olsrd-mod-dyn-gw
   - olsrd-mod-jsoninfo
   - olsrd-mod-nameservice
   - olsrd-mod-txtinfo

--- a/roles/cfg_openwrt/templates/gateway/bird.conf.j2
+++ b/roles/cfg_openwrt/templates/gateway/bird.conf.j2
@@ -32,14 +32,9 @@ protocol kernel kernel_v6_main {
 protocol kernel kernel_v4_main {
 	ipv4 {
 		table v4_main;
-		import filter {
-			if net != 0.0.0.0/0 then reject; # Import only Default Gateway from kernel
-			preference = 200; # Increase preference to beat babel route
-			accept;
-		};
+		import none;
 		export none;
 	};
-	learn all;
 }
 
 protocol kernel kernel_v4_babel_ff {
@@ -72,6 +67,21 @@ protocol pipe pipe_v4_main_to_babel_default {
 	peer table v4_babel_default;
 	export where net = 0.0.0.0/0;
 	import none;
+}
+
+##
+## Uplink static IPv4 route
+##
+{% if uplink['ipv4'] | ansible.utils.ipaddr('prefix') >= 30 %}
+  {% set v4_nexthop =  uplink['ipv4'] | ansible.utils.ipaddr('peer') %}
+{% else %}
+  {% set v4_nexthop =  uplink['ipv4'] | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') %}
+{%- endif %}
+
+protocol static static_uplink {
+	ipv4 { table v4_main; };
+	check link;
+	route 0.0.0.0/0 via {{ v4_nexthop }} dev "{{ uplink['ifname'] }}";
 }
 
 ##

--- a/roles/cfg_openwrt/templates/gateway/config/network.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/network.j2
@@ -1,3 +1,17 @@
+# IPv4 Soft Migration by priotizing Babel over OLSR
+# Static default Route is set by bird
+config rule
+	option priority 33100
+	option lookup 'babel-ff'
+
+config rule
+	option priority 33101
+	option lookup 'olsr-ff'
+
+config rule
+	option priority 33200
+	option lookup 'babel-default'
+
 config interface 'loopback'
 	option device 'lo'
 	option proto 'static'
@@ -12,9 +26,9 @@ config interface 'uplink'
 	option proto 'static'
 	option ipaddr '{{ uplink['ipv4'] }}'
 {% if uplink['ipv4'] | ansible.utils.ipaddr('prefix') >= 30 %}
-	option gateway '{{ uplink['ipv4'] | ansible.utils.ipaddr('peer') }}'
+#	option gateway '{{ uplink['ipv4'] | ansible.utils.ipaddr('peer') }}'
 {% else %}
-	option gateway '{{ uplink['ipv4'] | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') }}'
+#	option gateway '{{ uplink['ipv4'] | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') }}'
 {% endif %}
 {% if 'ipv6' in uplink %}
 	option ip6addr '{{ uplink['ipv6'] }}'

--- a/roles/cfg_openwrt/templates/gateway/config/olsrd.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/olsrd.j2
@@ -24,15 +24,6 @@ config LoadPlugin
 	option library 'olsrd_txtinfo'
 	option port '2006'
 
-config LoadPlugin
-	option library 'olsrd_dyn_gw'
-	list Ping '46.182.19.48'
-	list Ping '80.67.169.40'
-	list Ping '194.150.168.168'
-	option ignore '0'
-	option PingCmd 'ping -c 1 -q -I {{ uplink['ifname'] }} %s'
-	option PingInterval '30'
-
 config olsrd
 	option IpVersion '4'
 	option FIBMetric 'flat'
@@ -45,6 +36,13 @@ config olsrd
 	option OlsrPort '698'
 	option Willingness '3'
 	option TosValue '16'
+	option RtTable '20'
+	option RtTableDefault '21'
+# set rule priorities to some random high numbers to make sure they are never used
+# We define our own route policies in /etc/config/network
+	option RtTablePriority '34000'
+	option RtTableTunnelPriority '34020'
+	option RtTableDefaultPriority '34030'
   {% if sgw is defined and sgw %}
 	option SmartGateway 'yes'
 	option SmartGatewayUplink 'both'
@@ -71,10 +69,17 @@ config Interface
 	option Mode '{{ 'ether' if interface.get('ptp') else 'mesh' }}'
 	option LinkQualityMult 'default 1.0'
   {% endfor %}
+{% endif %}
 
-  {% if mgmt is defined %}
+{% if mgmt is defined %}
 config Hna4
 	option netmask '{{ mgmt['ipv4'] | ansible.utils.ipaddr('netmask') }}'
 	option netaddr '{{ mgmt['ipv4'] | ansible.utils.ipaddr('network') }}'
-  {% endif %}
 {% endif %}
+
+# Announce default route, its anyways not used for forwarding within BBB
+# We only need it to attract traffic from legacy mesh nodes, until babel
+# takes over in our core network
+config Hna4
+	option netmask '0.0.0.0'
+	option netaddr '0.0.0.0'


### PR DESCRIPTION
This involves few changes:
* Move IPv4 Static default route into bird, thus delete it from main network config
* Fix OLSR messing with policy routing (by setting its priorities super high)
* Remove OLSR dyngw which doesnt work with our policy routing approach and create a static default route HNA instead.