### PR TITLE
ilr, kitty, sav: simpler VLAN untagging

### DIFF
--- a/locations/ilr.yml
+++ b/locations/ilr.yml
@@ -19,55 +19,12 @@ hosts:
     # custom switch config script. Should be applied with a mechanism, that
     # includes files into root files system later on.
     host__rclocal__to_merge:
-      - '#'
-      - '# This script adjusts the configuration of vlans. This is especially'
-      - '# useful with uswflex and custom port configs'
-      - '#'
-      - ' '
-      - '. /lib/functions.sh'
-      - ' '
-      - 'handle_vlans() {'
-      - '	# untag the vlans on different ports based on their id'
-      - '	local uci_section="$1"'
-      - ' '
-      - '	config_get vlan "$uci_section" vlan'
-      - '	config_get ports "$uci_section" ports'
-      - ' '
-      - ' '
-      - '	case "$vlan" in'
-      - '		10)'
-      - '			# untag payload traffic for AF60 to Teufelsberg'
-      - "			port_config='lan1:t lan2 lan3:t lan4:t lan5:t' ;;"
-      - '		40)'
-      - '			# untag DHCP on ports 1 and 5 for convenient maintenance'
-      - "			port_config='lan1 lan2:t lan3:t lan4:t lan5' ;;"
-      - '		*)'
-      - '			# do nothing for the other vlans'
-      - '			return'
-      - '	esac'
-      - ' '
-      - '	# abort if config is applied already'
-      - '	if [ "$ports" = "$port_config" ]; then'
-      - '		printf "Vlan %d applied already.\n" "$vlan"'
-      - '		return'
-      - '	fi'
-      - ' '
-      - '	printf "Port number: %d\n" "$vlan"'
-      - '	printf "Port config: %s\n" "$port_config"'
-      - ' '
-      - '	printf "Configuring %s... " "$uci_section"'
-      - '	uci_set network "$uci_section" ports "$port_config"'
-      - '	printf "Done.\n"'
-      - '}'
-      - ' '
-      - 'config_load network'
-      - ' '
-      - 'config_foreach handle_vlans "bridge-vlan"'
-      - ' '
-      - 'uci commit network'
-      - 'sync'
-      - 'reload_config'
-
+      - |
+        # untag payload traffic for AF60 to Teufelsberg
+        uci set network.vlan_10.ports='lan1:t lan2 lan3:t lan4:t lan5:t'
+        # untag DHCP on ports 1 and 5 for convenient maintenance'
+        uci set network.vlan_40.ports='lan1 lan2:t lan3:t lan4:t lan5'
+        uci commit network; reload_config
 
 snmp_devices:
   - hostname: ilr-teufb

--- a/locations/kitty.yml
+++ b/locations/kitty.yml
@@ -21,56 +21,14 @@ hosts:
     role: corerouter
     model: "mikrotik_routerboard-750gr3"
     host__rclocal__to_merge:
-      - '#'
-      - '# This script adjusts the configuration of vlans.'
-      - '#'
-      - ' '
-      - '. /lib/functions.sh'
-      - ' '
-      - 'handle_vlans() {'
-      - '	# untag the vlans on different ports based on their id'
-      - '	local uci_section="$1"'
-      - ' '
-      - '	config_get vlan "$uci_section" vlan'
-      - '	config_get ports "$uci_section" ports'
-      - ' '
-      - ' '
-      - '	case "$vlan" in'
-      - '		50)'
-      - '			# untag MESH for uplink on port 1'
-      - "			port_config='wan lan2:t lan3:t lan4:t lan5:t' ;;"
-      - '		40)'
-      - '			# untag DHCP on port 2'
-      - "			port_config='wan:t lan2 lan3:t lan4:t lan5:t' ;;"
-      - '		42)'
-      - '			# untag mgmt on port 3'
-      - "			port_config='wan:t lan2:t lan3 lan4:t lan5:t' ;;"
-      - '		*)'
-      - '			# do nothing for the other vlans'
-      - '			return'
-      - '	esac'
-      - ' '
-      - '	# abort if config is applied already'
-      - '	if [ "$ports" = "$port_config" ]; then'
-      - '		printf "Vlan %d applied already.\n" "$vlan"'
-      - '		return'
-      - '	fi'
-      - ' '
-      - '	printf "Port number: %d\n" "$vlan"'
-      - '	printf "Port config: %s\n" "$port_config"'
-      - ' '
-      - '	printf "Configuring %s... " "$uci_section"'
-      - '	uci_set network "$uci_section" ports "$port_config"'
-      - '	printf "Done.\n"'
-      - '}'
-      - ' '
-      - 'config_load network'
-      - ' '
-      - 'config_foreach handle_vlans "bridge-vlan"'
-      - ' '
-      - 'uci commit network'
-      - 'sync'
-      - 'reload_config'
+      - |
+        # untag DHCP on port 2
+        uci set network.vlan_40.ports='wan:t lan2 lan3:t lan4:t lan5:t'
+        # untag mgmt on port 3
+        uci set network.vlan_42.ports='wan:t lan2:t lan3 lan4:t lan5:t'
+        # untag MESH for uplink on port 1
+        uci set network.vlan_50.ports='wan lan2:t lan3:t lan4:t lan5:t'
+        uci commit network; reload_config
 
 networks:
   - vid: 40

--- a/locations/sav.yml
+++ b/locations/sav.yml
@@ -21,57 +21,14 @@ hosts:
     role: corerouter
     model: "mikrotik_routerboard-750gr3"
     host__rclocal__to_merge:
-      - '#'
-      - '# This script adjusts the configuration of vlans. This is especially'
-      - '# useful with uswflex and custom port configs'
-      - '#'
-      - ' '
-      - '. /lib/functions.sh'
-      - ' '
-      - 'handle_vlans() {'
-      - '	# untag the vlans on different ports based on their id'
-      - '	local uci_section="$1"'
-      - ' '
-      - '	config_get vlan "$uci_section" vlan'
-      - '	config_get ports "$uci_section" ports'
-      - ' '
-      - ' '
-      - '	case "$vlan" in'
-      - '		10)'
-      - '			# untag payload traffic for Wave to Emma'
-      - "			port_config='wan lan2:t lan3:t lan4:t lan5:t' ;;"
-      - '		40)'
-      - '			# untag DHCP on port 2'
-      - "			port_config='wan:t lan2 lan3:t lan4:t lan5:t' ;;"
-      - '		50)'
-      - '			# untag port 3 for local backup uplink'
-      - "			port_config='wan:t lan2:t lan3 lan4:t lan5:t' ;;"
-      - '		*)'
-      - '			# do nothing for the other vlans'
-      - '			return'
-      - '	esac'
-      - ' '
-      - '	# abort if config is applied already'
-      - '	if [ "$ports" = "$port_config" ]; then'
-      - '		printf "Vlan %d applied already.\n" "$vlan"'
-      - '		return'
-      - '	fi'
-      - ' '
-      - '	printf "Port number: %d\n" "$vlan"'
-      - '	printf "Port config: %s\n" "$port_config"'
-      - ' '
-      - '	printf "Configuring %s... " "$uci_section"'
-      - '	uci_set network "$uci_section" ports "$port_config"'
-      - '	printf "Done.\n"'
-      - '}'
-      - ' '
-      - 'config_load network'
-      - ' '
-      - 'config_foreach handle_vlans "bridge-vlan"'
-      - ' '
-      - 'uci commit network'
-      - 'sync'
-      - 'reload_config'
+      - |
+        # untag payload traffic for Wave to Emma
+        uci set network.vlan_10.ports='wan lan2:t lan3:t lan4:t lan5:t'
+        # untag DHCP on port 2
+        uci set network.vlan_40.ports='wan:t lan2 lan3:t lan4:t lan5:t'
+        # untag port 3 for local backup uplink
+        uci set network.vlan_50.ports='wan:t lan2:t lan3 lan4:t lan5:t'
+        uci commit network; reload_config
 
 snmp_devices:
   - hostname: sav-emma


### PR DESCRIPTION
With https://github.com/freifunk-berlin/bbb-configs/commit/58b894c641b9a3608b9c3bac93e35e0571133ae8 we can now configure VLAN tagging using the bridge names.