### PR TITLE
Network (Uplink): Implement option "dhcp_client"

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -186,7 +186,7 @@ tunnel can be an easy and safe solution. In that case you can add one or more tu
 ```yml
   - vid: 50
     role: uplink
-
+    dhcp_client: false         # request ip address from dhcp server (default: false)
   - role: tunnel
     ifname: ts_wg0
     mtu: 1280

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -74,6 +74,8 @@ config interface '{{ name }}'
     {% elif role == 'corerouter' and network['role'] == 'mesh' %}
 	option proto 'static'
 	option ipaddr '{{ network['prefix'] }}'
+    {% elif role == 'corerouter' and network['role'] == 'uplink' and network['dhcp_client'] is defined and network['dhcp_client'] %}
+	option proto 'dhcp'
     {% else %}
 	option proto 'none'
     {% endif %}


### PR DESCRIPTION
This PR implements on "**corerouter**" the option "dhcp_client" as bool on **uplink** and sets `proto: dhcp`. The option is documented and by default disabled and not set to keep the current behavier of the devices.

**Example** locations/(###my_example_location###.yml):
```
  - vid: 50
    role: uplink
    dhcp_client: false
```

**Current:**
```
config interface 'uplink'
	option device 'br-uplink'
	option proto 'none'
```

**Result:**

```
config interface 'uplink'
	option device 'br-uplink'
	option proto 'dhcp'
```

**Maybe helpfully in issue: #1045** 