### PR TITLE
Tunspace: Disable debug mode by default

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
@@ -9,7 +9,7 @@ config tunspace "tunspace"
   option uplink_ifname "{{ ifname }}"
   option uplink_mode "{{ mode }}"
   option maintenance_interval 60
-  option debug 1
+  option debug 0
 {% endfor %}
 
 {% for tunnel in networks | selectattr('role', 'equalto', 'tunnel') %}


### PR DESCRIPTION
This PR disables the debug mode in tunspace to relax the syslog.
To be hornest: **it hides every minute very important messages.**

![Screenshot 2025-01-07 214820](https://github.com/user-attachments/assets/13998a29-9216-43e5-ad74-f7274a3a2cfb)
