### PR TITLE
Promote TP-Link EAP225 v1 and Ubiquiti UniFi AC Mesh to OpenWRT 24.10

### DIFF
--- a/group_vars/model_tplink_eap225_outdoor_v1.yml
+++ b/group_vars/model_tplink_eap225_outdoor_v1.yml
@@ -4,6 +4,8 @@ brand_nice: TP-Link
 model_nice: EAP225
 version_nice: v1
 
+openwrt_version: 24.10-SNAPSHOT
+
 int_port: eth0
 
 model__packages__to_merge:

--- a/group_vars/model_ubnt_unifiac_mesh.yml
+++ b/group_vars/model_ubnt_unifiac_mesh.yml
@@ -3,6 +3,8 @@ target: ath79/generic
 brand_nice: Ubiquiti
 model_nice: UniFi AC Mesh
 
+openwrt_version: 24.10-SNAPSHOT
+
 model__packages__to_merge:
   - "-kmod-ath10k-ct -ath10k-firmware-qca988x-ct"
   - "kmod-ath10k ath10k-firmware-qca988x"


### PR DESCRIPTION
Already running at multiple locations (e16outdoor, funkigel, hdk-30).