### PR TITLE
hdk,w38b,weidenbaum,funkigel: enable legacy_rates

### DIFF
--- a/locations/funkigel.yml
+++ b/locations/funkigel.yml
@@ -15,6 +15,10 @@ hosts:
     role: corerouter
     model: "ubnt_unifiac-mesh"
     wireless_profile: funkigel
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 snmp_devices:
 

--- a/locations/hdk-0.yml
+++ b/locations/hdk-0.yml
@@ -10,6 +10,10 @@ hosts:
     role: corerouter
     model: "avm_fritzbox-7530"
     wireless_profile: freifunk_default
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 ipv6_prefix: '2001:bf7:840:2000::/56'
 

--- a/locations/hdk-13.yml
+++ b/locations/hdk-13.yml
@@ -10,6 +10,10 @@ hosts:
     role: corerouter
     model: "tplink_tl-mr3020-v3"
     wireless_profile: freifunk_default
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 ipv6_prefix: '2001:bf7:840:3100::/56'
 

--- a/locations/hdk-30.yml
+++ b/locations/hdk-30.yml
@@ -18,6 +18,10 @@ hosts:
     role: corerouter
     model: "ubnt_unifiac-mesh"
     wireless_profile: freifunk_default
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 ipv6_prefix: "2001:bf7:840:1b00::/56"
 

--- a/locations/hdk-64.yml
+++ b/locations/hdk-64.yml
@@ -10,6 +10,10 @@ hosts:
     role: corerouter
     model: "comfast_cf-ew72"
     wireless_profile: freifunk_default
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 ipv6_prefix: '2001:bf7:840:2300::/56'
 

--- a/locations/hdk-66b.yml
+++ b/locations/hdk-66b.yml
@@ -10,6 +10,10 @@ hosts:
     role: corerouter
     model: "tplink_eap225-outdoor-v3"
     wireless_profile: freifunk_default
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 ipv6_prefix: '2001:bf7:840:1f00::/56'
 

--- a/locations/w38b.yml
+++ b/locations/w38b.yml
@@ -17,6 +17,10 @@ hosts:
     model: "dlink_covr-x1860-a1"
     wireless_profile: freifunk_default
     mac_override: {eth0: 0c:0e:76:cf:2e:3a}
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 snmp_devices:
   - hostname: w38b-sama

--- a/locations/weidenbaum.yml
+++ b/locations/weidenbaum.yml
@@ -13,6 +13,10 @@ hosts:
     role: corerouter
     model: "ubnt_unifiac-mesh"
     wireless_profile: freifunk_default
+    host__rclocal__to_merge:
+      - |
+        # Enable legacy rates to enable meshing with neighbors
+        for radio in $(uci show wireless | grep "=wifi-device" | cut -d. -f2 | cut -d= -f1); do uci set wireless.$radio.legacy_rates='1'; done; uci commit wireless; wifi reload
 
 snmp_devices:
 


### PR DESCRIPTION
Without this 24.10 nodes have issues meshing with older nodes via 2.4 GHz