### PR TITLE
model: bump zyxel_nwa50ax & cudy_x6-v1 & x86-64 to 24.10

### DIFF
--- a/group_vars/model_cudy_x6_v1.yml
+++ b/group_vars/model_cudy_x6_v1.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 24.10-SNAPSHOT
 brand_nice: Cudy
 model_nice: X6
 version_nice: v1

--- a/group_vars/model_x86_64.yml
+++ b/group_vars/model_x86_64.yml
@@ -2,7 +2,8 @@
 target: x86/64
 override_target: generic
 image_search_pattern: "*-ext4-combined.img*"
-model_nice: 32-/64-bit Computer
+openwrt_version: 24.10-SNAPSHOT
+model_nice: x86/64 Generic
 
 int_port: eth0
 

--- a/group_vars/model_zyxel_nwa50ax.yml
+++ b/group_vars/model_zyxel_nwa50ax.yml
@@ -1,5 +1,6 @@
 ---
 target: ramips/mt7621
+openwrt_version: 24.10-SNAPSHOT
 brand_nice: ZyXEL
 model_nice: NWA50AX
 

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -20,38 +20,37 @@ ipv6_prefix: 2001:bf7:820:2c00::/56
 
 hosts:
 
-  # Thinkcentre M720q, i5-8500T, 16GB RAM, 1TB NVMe
-  # eth0      - Intel I219 V7
-  # eth1 eth2 - ConnectX-4 Lx CX4121B
+  # Lenovo 10RS002AGE / Thinkcentre M920q, i5-8600T, 16GB RAM, 256GB NVMe
+  # eth0 eth1 - ConnectX-4 Lx MCX4121A-XCHT - PCIe SMBus taped off (Pins 5 & 6)
+  # eth2      - Intel I219-LM V7
   - hostname: hway-core
     role: corerouter
-    int_port: eth1
+    int_port: eth0
     model: x86-64
-    openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
     host__packages__to_merge:
       - kmod-mlx5-core
     host__rclocal__to_merge:
-      # There's a decades-old TX offload bug in intel gigabit controllers
+      # There's a decades-old RX/TX offload bug in intel gigabit controllers
       # which regularly hangs the card. It gets reset automatically,
-      # but still results in regular ~15s downtimes. Disable offloads.
-      - ethtool -K eth0 tx off rx off
+      # but that still results in very frequent ~15s downtimes.
+      # To avoid this bug, we disable RX/TX hardware offloading.
+      - ethtool -K eth2 tx off rx off
     host__disabled_services__to_merge:
+      # Disabled but present, just in case we might need it
       - tunspace
 
   - hostname: hway-indoor
     role: ap
     wireless_profile: hway
     model: zyxel_nwa50ax
-    openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
   - hostname: hway-street
     role: ap
     wireless_profile: hway
     model: cudy_ap3000outdoor-v1
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
+
+log_size: 1024
 
 snmp_devices:
 
@@ -101,7 +100,7 @@ networks:
       hway-street: 5     # .255.253
 
   - vid: 50
-    ifname: eth0
+    ifname: eth2
     role: uplink
     untagged: true
 

--- a/locations/suedblock.yml
+++ b/locations/suedblock.yml
@@ -19,8 +19,6 @@ hosts:
     model: "cudy_x6-v1"
     wireless_profile: freifunk_default
     dhcp_no_ping: false
-    openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
 # 10.248.13.0/24
 # 10.248.13.0/29 - mgmt


### PR DESCRIPTION
I updated the following:
- [x] suedblock-*
- [x] rotelilly-*
- [x] cafe-wostok-*
- [x] kirchhof-*
- [x] hway-*

This also included some Fritzboxes 4040/7530 and SXTsq 5 ac, which have already been bumped in the repo