### PR TITLE
add link to openwrt build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ source venv/bin/activate
 pip3 install -r requirements.txt
 ```
 
+You can find what dependencies you need for your specific linux-distro [here](https://openwrt.org/docs/guide-developer/toolchain/install-buildsystem#linux_gnu-linux_distributions).
+
 ### 2. Generate images
 
 You can generate images using the generate-images script that brings up a menu


### PR DESCRIPTION
In der readme fehlt ein Eintrag, wo die die Build dependencies für die verschiedene Linux-Distributionen zu finden sind. Dieser wird hiermit hinzugefügt-