### PR TITLE
kiehlufer: use Cudy AP3000 for corerouter

### DIFF
--- a/group_vars/model_cudy_ap3000_v1.yml
+++ b/group_vars/model_cudy_ap3000_v1.yml
@@ -1,0 +1,20 @@
+---
+target: mediatek/filogic
+openwrt_version: snapshot
+brand_nice: Cudy
+model_nice: AP3000
+version_nice: v1
+
+int_port: eth0
+
+wireless_devices:
+  - name: 11a_standard
+    band: 5g
+    htmode_prefix: HE
+    path: platform/soc/18000000.wifi+1
+    ifname_hint: wlan5
+  - name: 11g_standard
+    band: 2g
+    htmode_prefix: HE
+    path: platform/soc/18000000.wifi
+    ifname_hint: wlan2

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -28,7 +28,7 @@ hosts:
 
   - hostname: kiehlufer-core
     role: corerouter
-    model: "cudy_x6-v1"
+    model: "cudy_ap3000-v1"
     wireless_profile: freifunk_default
     openwrt_version: 24.10-SNAPSHOT
     log_size: 1024


### PR DESCRIPTION
It has a Filogic SoC which is much faster than MT7621.
Routing is not limited to ~300 Mbps anymore now.