### PR TITLE
Treewide: Set 'log_size' to 1024 except devices with small memory

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -1,7 +1,6 @@
 ---
 zonename: 'Europe/Berlin'
 timezone: 'CET-1CEST,M3.5.0,M10.5.0/3'
-log_size: 64
 
 # TODO: find a second good DNS upstream in Berlin
 dns_servers:

--- a/locations/elsekiehl.yml
+++ b/locations/elsekiehl.yml
@@ -30,7 +30,6 @@ hosts:
     model: "avm_fritzbox-7530"
     wireless_profile: freifunk_default
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
 ipv6_prefix: '2001:bf7:820:1800::/56'
 

--- a/locations/huette.yml
+++ b/locations/huette.yml
@@ -17,7 +17,6 @@ hosts:
     model: "zyxel_nwa55axe"
     wireless_profile: freifunk_default
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
 ipv6_prefix: '2001:bf7:830:2600::/56'
 

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -50,8 +50,6 @@ hosts:
     model: cudy_ap3000outdoor-v1
     openwrt_version: 24.10-SNAPSHOT
 
-log_size: 1024
-
 snmp_devices:
 
   - hostname: hway-kiehlufer

--- a/locations/kiehl71.yml
+++ b/locations/kiehl71.yml
@@ -31,7 +31,6 @@ hosts:
     model: "avm_fritzbox-7530"
     wireless_profile: freifunk_default
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
 ipv6_prefix: '2001:bf7:750:3200::/56'
 

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -31,14 +31,12 @@ hosts:
     model: "cudy_ap3000-v1"
     wireless_profile: freifunk_default
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
   - hostname: kiehlufer-huette
     role: ap
     model: "zyxel_nwa55axe"
     wireless_profile: kiehlufer5g
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
   - hostname: kiehlufer-nf-wbp1
     role: ap

--- a/locations/kub.yml
+++ b/locations/kub.yml
@@ -18,7 +18,6 @@ hosts:
     role: ap
     model: "cudy_x6-v1"
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
 snmp_devices:
   - hostname: kub-simeon

--- a/locations/simeon.yml
+++ b/locations/simeon.yml
@@ -14,8 +14,6 @@ hosts:
     model: "ubnt_edgerouter-x"
     poe_on: []
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
-
 
 snmp_devices:
 

--- a/locations/wilde.yml
+++ b/locations/wilde.yml
@@ -28,7 +28,6 @@ hosts:
     mac_override:
       eth0: 2c:c8:1b:6b:e5:d2
     openwrt_version: 24.10-SNAPSHOT
-    log_size: 1024
 
   - hostname: wilde-nf-n
     role: ap

--- a/roles/cfg_openwrt/templates/common/config/system.j2
+++ b/roles/cfg_openwrt/templates/common/config/system.j2
@@ -3,7 +3,11 @@ config system
         option zonename '{{ zonename }}'
         option timezone '{{ timezone }}'
         option ttylogin '0'
-        option log_size '{{ log_size }}'
+{% if low_mem | default(false) %}
+        option log_size '{{ log_size | default(64)}}'
+{% else %}
+        option log_size '{{ log_size | default(1024)}}'
+{% endif %}
         option urandom_seed '0'
         option compat_version '9.9' # hardcoded to a bbb-configs exclusive version identifier, matches patch in image builder, because we dont retain device config.
 {% if role == 'corerouter' or role  == 'gateway' %}


### PR DESCRIPTION
This was discussed in #1186