### PR TITLE
all: change ieee80211w to required

### DIFF
--- a/group_vars/all/wireless_profiles.yml
+++ b/group_vars/all/wireless_profiles.yml
@@ -43,7 +43,7 @@ all__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
   - name: freifunk_default
     ifaces:
@@ -60,7 +60,7 @@ all__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: mesh
         mesh_id: Mesh-Freifunk-Berlin
@@ -84,7 +84,7 @@ all__wireless_profiles__to_merge:
       #   network: dhcp
       #   radio: [11a_standard, 11g_standard]
       #   ifname_hint: ffowe
-      #   ieee80211w: 1
+      #   ieee80211w: 2
 
       - mode: mesh
         mesh_id: Mesh-Freifunk
@@ -108,7 +108,7 @@ all__wireless_profiles__to_merge:
       #   network: dhcp
       #   radio: [11a_standard, 11g_standard]
       #   ifname_hint: ffowe
-      #   ieee80211w: 1
+      #   ieee80211w: 2
 
       - mode: mesh
         mesh_id: Mesh-Freifunk-Berlin

--- a/locations/colbe15.yml
+++ b/locations/colbe15.yml
@@ -84,7 +84,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: colbe15-home.freifunk.net

--- a/locations/ekke.yml
+++ b/locations/ekke.yml
@@ -107,7 +107,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: Interwebz

--- a/locations/hts4.yml
+++ b/locations/hts4.yml
@@ -124,7 +124,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: hts4

--- a/locations/hway.yml
+++ b/locations/hway.yml
@@ -134,7 +134,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
         owe_transition_ifname_hint: ff
-        ieee80211w: 1
+        ieee80211w: 2
       - mode: mesh
         mesh_id: Mesh-Freifunk-Berlin
         radio: [11a_standard, 11g_standard, 11a_mesh]

--- a/locations/kiehlufer.yml
+++ b/locations/kiehlufer.yml
@@ -205,7 +205,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
       - mode: mesh
         mesh_id: Mesh-Freifunk-Berlin
         radio: [11a_standard, 11a_mesh]

--- a/locations/koepi.yml
+++ b/locations/koepi.yml
@@ -138,7 +138,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: koepi

--- a/locations/newyorck.yml
+++ b/locations/newyorck.yml
@@ -172,7 +172,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: newyorck

--- a/locations/noki.yml
+++ b/locations/noki.yml
@@ -202,7 +202,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
         owe_transition_ifname_hint: ff
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: noki

--- a/locations/q216.yml
+++ b/locations/q216.yml
@@ -126,7 +126,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: Private Wifi

--- a/locations/rauchhaus.yml
+++ b/locations/rauchhaus.yml
@@ -150,7 +150,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: rauchhaus

--- a/locations/stadalbert.yml
+++ b/locations/stadalbert.yml
@@ -147,7 +147,7 @@ location__wireless_profiles__to_merge:
         network: dhcp
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: BAS-Office

--- a/locations/tempelwg.yml
+++ b/locations/tempelwg.yml
@@ -117,7 +117,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
         owe_transition_ifname_hint: ff
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: o2-WLAN68

--- a/locations/wilgu10.yml
+++ b/locations/wilgu10.yml
@@ -157,7 +157,7 @@ location__wireless_profiles__to_merge:
         radio: [11a_standard, 11g_standard]
         ifname_hint: ffowe
         owe_transition_ifname_hint: ff
-        ieee80211w: 1
+        ieee80211w: 2
 
       - mode: ap
         ssid: losWlanosLocos


### PR DESCRIPTION
`ieee80211w: 1` does not work with quite some devices, mainly windows based devices but changing it to `ieee80211w: 2` always worked. I therefore suggest to change this to `ieee80211w: 2` as new default as it solved compatibility issues for me. Let me know if you have any concerns.