### PR TITLE
magda: add switch & public DHCP network

### DIFF
--- a/locations/magda.yml
+++ b/locations/magda.yml
@@ -49,6 +49,10 @@ snmp_devices:
     address: 10.31.83.116
     snmp_profile: airos_8
 
+  - hostname: magda-switch-unten
+    address: 10.31.83.122
+    snmp_profile: swos_lite
+
 airos_dfs_reset:
   - name: "magda-ost-5ghz"
     target: "10.31.83.116"
@@ -92,6 +96,7 @@ networks:
       magda-ap3: 7
       # magda-ap4: 8
       magda-ap-remise: 9
+      magda-switch-unten: 10
 
   - vid: 40
     role: dhcp

--- a/locations/magda.yml
+++ b/locations/magda.yml
@@ -107,6 +107,16 @@ networks:
     assignments:
       magda-core: 1
 
+  - vid: 41
+    role: dhcp
+    name: pubdhcp
+    prefix: 10.248.42.48/28
+    ipv6_subprefix: 2
+    inbound_filtering: false
+    enforce_client_isolation: true
+    assignments:
+      magda-core: 1
+
 location__channel_assignments_11a_standard__to_merge:
   magda-ap1: 48-20
   magda-ap2: 36-20


### PR DESCRIPTION
This adds an additional DHCP network without `inbound_filtering` for client devices attached by cable.

There's also a new Mikrotik PoE switch downstairs, replacing the SFP/GbE media converter. It's configured to have the new VLAN 41 untagged on all non-magda-ports.