### PR TITLE
templates: fix roaming bug by avoiding bridge in DSA setups

### DIFF
--- a/roles/cfg_openwrt/templates/common/config/dsa.network.inc
+++ b/roles/cfg_openwrt/templates/common/config/dsa.network.inc
@@ -6,7 +6,7 @@ config device
   {% set portmapping = [] %}
   {% for port in dsa_ports %}
     {% set tagged = not network.get('untagged') %}
-    {{ portmapping.append(port|string + (":t" if tagged else "")) }}
+    {{ portmapping.append(port|string + (":t" if tagged else ":u")) }}
   {%- endfor %}
 
 config bridge-vlan 'vlan_{{ network['vid'] }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/tunspace.j2
@@ -1,8 +1,10 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
+{% import 'libraries/network.j2' as libnetwork with context %}
+
 {% for uplink in networks | selectattr('role', 'equalto', 'uplink') %}
   {% set name = uplink['name'] if 'name' in uplink else 'uplink' %}
   {% set mode = uplink['uplink_mode'] if 'uplink_mode' in uplink else 'bridge' %}
-  {% set ifname = uplink['ifname'] if mode == 'direct' else 'br-'+name %}
+  {% set ifname = libnetwork.getIfname(uplink) %}
 
 config tunspace "tunspace"
   # Namespace where the uplink will live.

--- a/roles/cfg_openwrt/templates/libraries/network.j2
+++ b/roles/cfg_openwrt/templates/libraries/network.j2
@@ -7,7 +7,7 @@
     {% set ifname = "" %}
     {% if isBridgeNeeded(network) | from_json %}
         {% set ifname = getBridgeIfname(network) %}
-    {% elif network.get('mesh_ap') == inventory_hostname %}
+    {% elif int_port is defined and network.get('mesh_ap') == inventory_hostname %}
         {% set ifname = libwireless.getLocalAdhocIfnameByNetwork(network) %}
     {% else %}
         {% set ifname = getPortIfname(network) %}
@@ -45,9 +45,9 @@
 {# Do we need to create a logical bridge for that network to bridge to wireless interface or are we not participating. This does not affect the switch configuration
  # Warning: returns a bool. Use |from_json filter when calling #}
 {% macro isBridgeNeeded(network) %}
-{{- (getUciIfname(network) in getWirelessNetworks()
+{{- (int_port is defined and (getUciIfname(network) in getWirelessNetworks()
      or (role == 'ap' and network.get('mesh_ap') == inventory_hostname)
-     or (role == 'corerouter' and network['role'] == 'uplink' and network.get('uplink_mode') != 'direct')) | to_json -}}
+     or (role == 'corerouter' and network['role'] == 'uplink' and network.get('uplink_mode') != 'direct'))) | to_json -}}
 {% endmacro %}
 
 {# Do we need to configure a port or is this network only connected local (e.g. Mesh Endpoint on the core router)


### PR DESCRIPTION
Only use bridges with switch ports devices. Remove bridge in DSA configurations, as it causes roaming issues.

Maybe before checking int_port we could also check for dsa_ports.