### PR TITLE
templates: add option to enable flow offloading

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -59,4 +59,3 @@ mesh_metric_adhoc_11g_standard: 2560
 # https://openwrt.org/docs/guide-user/perf_and_log/flow_offloading
 # Possible values: none, sw, hw
 flow_offload: none
-

--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -59,3 +59,4 @@ mesh_metric_adhoc_11g_standard: 2560
 # https://openwrt.org/docs/guide-user/perf_and_log/flow_offloading
 # Possible values: none, sw, hw
 flow_offload: none
+

--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -54,3 +54,8 @@ mesh_metric_tunnel_in: 3072
 # Default mesh metrics in inbound direction (rxcost) for adhoc like interfaces
 mesh_metric_adhoc_11a_standard: 2048
 mesh_metric_adhoc_11g_standard: 2560
+
+# Allow enabling flow offloading
+# https://openwrt.org/docs/guide-user/perf_and_log/flow_offloading
+# Possible values: none, sw, hw
+flow_offload: none

--- a/roles/cfg_openwrt/templates/ap/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/ap/config/firewall.j2
@@ -6,6 +6,12 @@ config defaults
   option output 'ACCEPT'
   option forward 'REJECT'
   option drop_invalid '0'
+{% if flow_offload=="sw" %}
+  option flow_offloading '1'
+{% elif flow_offload=="hw" %}
+  option flow_offloading '1'
+  option flow_offloading_hw '1'
+{% endif %}
 
 config zone 'zone_freifunk'
   option name 'freifunk'

--- a/roles/cfg_openwrt/templates/corerouter/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/firewall.j2
@@ -11,6 +11,12 @@ config defaults
 	option output 'ACCEPT'
 	option forward 'REJECT'
 	option drop_invalid '0'
+{% if flow_offload=="sw" %}
+	option flow_offloading '1'
+{% elif flow_offload=="hw" %}
+	option flow_offloading '1'
+	option flow_offloading_hw '1'
+{% endif %}
 
 config zone 'zone_freifunk'
 	option name 'freifunk'

--- a/roles/cfg_openwrt/templates/gateway/config/firewall.j2
+++ b/roles/cfg_openwrt/templates/gateway/config/firewall.j2
@@ -6,7 +6,12 @@ config defaults
 	option input		ACCEPT
 	option output		ACCEPT
 	option forward		REJECT
-
+{% if flow_offload=="sw" %}
+	option flow_offloading '1'
+{% elif flow_offload=="hw" %}
+	option flow_offloading '1'
+	option flow_offloading_hw '1'
+{% endif %}
 
 config zone
 	option name		freifunk


### PR DESCRIPTION
Add option to enable flow offloading:

https://openwrt.org/docs/guide-user/perf_and_log/flow_offloading


this massively improves the routing performance on several devices


e.g.:
- Fritzbox 7530 from ~250 Mbits bidirectional to 500 (limited by the cpu that is connected only via gigabit to the switch)
- EX400 from ~200Mbits to ~950 bidirectional when using both interfaces



Because of the pitfalls mentioned in the wiki page i would like to test this on a few selected sites