### PR TITLE
model: do single-port DSA properly on Zyxel

### DIFF
--- a/group_vars/model_zyxel_nwa50ax.yml
+++ b/group_vars/model_zyxel_nwa50ax.yml
@@ -4,7 +4,8 @@ openwrt_version: 24.10-SNAPSHOT
 brand_nice: ZyXEL
 model_nice: NWA50AX
 
-int_port: lan
+dsa_ports:
+  - lan
 
 wireless_devices:
   - name: 11a_standard

--- a/group_vars/model_zyxel_nwa55axe.yml
+++ b/group_vars/model_zyxel_nwa55axe.yml
@@ -2,7 +2,8 @@
 target: ramips/mt7621
 brand_nice: ZyXEL
 model_nice: NWA55AXE
-int_port: lan
+dsa_ports:
+  - lan
 
 openwrt_version: 24.10-SNAPSHOT
 


### PR DESCRIPTION
NWA50AX tested with lause-ap1 and hway-indoor.
NWA55AXE tested with huette-core.

There's a few other devices that should be changed to `dsa_ports`, e.g. the Cudys and D-Links. Others already do it correctly, e.g. Unifi 6 Lite.