### PR TITLE
Fix smallies

### DIFF
--- a/group_vars/all/general.yml
+++ b/group_vars/all/general.yml
@@ -32,7 +32,7 @@ sysupgrade_preserve_custom_files:
 
 image_search_pattern: "*-sysupgrade.*"
 
-all_sysctl__to_merge:
+all__sysctl__to_merge:
   # when oom kicks in most likely something broke. Panic/Reboot then
   vm.panic_on_oom: 1
 

--- a/group_vars/role_corerouter/general.yml
+++ b/group_vars/role_corerouter/general.yml
@@ -2,5 +2,5 @@
 
 wireless_profile: disable
 
-role_corerouter_sysctl__to_merge:
+role_corerouter__sysctl__to_merge:
   net.netfilter.nf_conntrack_max: 131072

--- a/group_vars/role_gateway/general.yml
+++ b/group_vars/role_gateway/general.yml
@@ -21,7 +21,7 @@ freifunk_wahlkreis_announcement_prefix: 44
 local_asn: 44194
 peer_asn: 25291
 
-role_gateway_sysctl__to_merge:
+role_gateway__sysctl__to_merge:
   net.netfilter.nf_conntrack_max: 524288
 
 ## WIREGUARD SECTION

--- a/roles/cfg_openwrt/tasks/imagebuilder.yml
+++ b/roles/cfg_openwrt/tasks/imagebuilder.yml
@@ -105,7 +105,7 @@
     path: "{{ configs_dir }}/etc/apk/repositories.d/falter.list"
     line: "{{ feed }}"
     create: true
-    mode: "0644"
+    mode: "644"
   when: 'feed_version is defined and openwrt_version == "snapshot"'
 
 - name: Add falter APK feed key
@@ -153,7 +153,7 @@
   copy:
     src: "{{ build_dir }}/target/linux/{{ (target | split('/'))[0] }}/base-files/etc/inittab"
     dest: "{{ configs_dir }}/etc/inittab"
-    mode: "0644"
+    mode: "644"
   when: additional_serial_ports is defined
 
 - name: Configure additional serial ports in inittab

--- a/roles/cfg_openwrt/tasks/merge_vars.yml
+++ b/roles/cfg_openwrt/tasks/merge_vars.yml
@@ -1,44 +1,44 @@
 ---
 - name: Merge packages variable
   merge_vars:
-    suffix_to_merge: packages__to_merge
+    suffix_to_merge: __packages__to_merge
     merged_var_name: packages
     expected_type: list
 
 - name: Merge disabled_services variable
   merge_vars:
-    suffix_to_merge: disabled_services__to_merge
+    suffix_to_merge: __disabled_services__to_merge
     merged_var_name: disabled_services
     expected_type: list
 
 - name: Merge wireless_profiles variable
   merge_vars:
-    suffix_to_merge: wireless_profiles__to_merge
+    suffix_to_merge: __wireless_profiles__to_merge
     merged_var_name: wireless_profiles
     expected_type: list
 
 - name: Merge ssh_keys variable
   merge_vars:
-    suffix_to_merge: ssh_keys__to_merge
+    suffix_to_merge: __ssh_keys__to_merge
     merged_var_name: ssh_keys
     expected_type: list
   when: ssh_keys is undefined
 
 - name: Merge sysctl variable
   merge_vars:
-    suffix_to_merge: sysctl__to_merge
+    suffix_to_merge: __sysctl__to_merge
     merged_var_name: sysctl
     expected_type: dict
 
 - name: Merge rclocal variable
   merge_vars:
-    suffix_to_merge: rclocal__to_merge
+    suffix_to_merge: __rclocal__to_merge
     merged_var_name: rclocal
     expected_type: list
 
 - name: "Merge channel_assignments variables"
   merge_vars:
-    suffix_to_merge: "{{ item.split('__')[1] + '__to_merge' }}"
+    suffix_to_merge: "__{{ item.split('__')[1] + '__to_merge' }}"
     merged_var_name: "{{ item.split('__')[1] }}"
     expected_type: dict
   loop: "{{ hostvars[inventory_hostname] | select('match', '.*__channel_assignments_.*') }}"

--- a/roles/cfg_openwrt/templates/common/config/network.j2
+++ b/roles/cfg_openwrt/templates/common/config/network.j2
@@ -81,11 +81,11 @@ config interface '{{ name }}'
     {% else %}
 	option proto 'none'
     {% endif %}
-  {% endif %}
-  {% if role == 'corerouter' and ipv6_prefix is defined %}
-    {% if 'ipv6_subprefix' in network %}
-      {% set subprefix = ipv6_prefix | ansible.utils.ipsubnet('64', network['ipv6_subprefix']) %}
+    {% if role == 'corerouter' and ipv6_prefix is defined %}
+      {% if 'ipv6_subprefix' in network %}
+        {% set subprefix = ipv6_prefix | ansible.utils.ipsubnet('64', network['ipv6_subprefix']) %}
 	option ip6addr '{{ subprefix | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}/{{ '128' if network['role'] == 'mesh' else '64' }}'
+      {% endif %}
     {% endif %}
   {% endif %}
 


### PR DESCRIPTION
merge_vars: fix shared-prefix conflicts

    Example: the suffix "files__to_merge" also matches
    "wireless_profiles__to_merge" which caused funny issues.

    Let's also match on the leading underscores to prevent that.

    group_vars/all/general.yml             |  2 +-
    group_vars/role_corerouter/general.yml |  2 +-
    group_vars/role_gateway/general.yml    |  2 +-
    roles/cfg_openwrt/tasks/merge_vars.yml | 14 +++++++-------
    4 files changed, 10 insertions(+), 10 deletions(-)

render_etc: fix file permissions syntax

    roles/cfg_openwrt/tasks/render_etc.yml | 6 +++---
    1 file changed, 3 insertions(+), 3 deletions(-)

network: fix stray ip6addr option

    This piece was outside of the corresponding `network` UCI block.
    In certain cases this `ip6addr` option was printed alone.
    This means it was parsed as if it belonged to the `network` block
    that printed right before.

    No content change, just moving it up into the if-endif-block that
    was being closed right above.

    roles/cfg_openwrt/templates/common/config/network.j2 | 8 ++++----
    1 file changed, 4 insertions(+), 4 deletions(-)