### PR TITLE
treewide: use :u syntax

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -88,9 +88,9 @@ For special use cases you can add lines to a script file. This script runs once 
     host__rclocal__to_merge:
       - |
         # Untag mesh traffic for a Airfiber as they cant do it themself
-        uci set network.vlan_10.ports='lan1:t lan2 lan3:t lan4:t lan5:t'
+        uci set network.vlan_10.ports='lan1:t lan2:u lan3:t lan4:t lan5:t'
         # Untag DHCP on ports 4 and 5 for convenient maintenance'
-        uci set network.vlan_40.ports='lan1:t lan2:t lan3:t lan4 lan5'
+        uci set network.vlan_40.ports='lan1:t lan2:t lan3:t lan4:u lan5:u'
         uci commit network; reload_config
 ```
 

--- a/locations/baumex.yml
+++ b/locations/baumex.yml
@@ -21,14 +21,14 @@ hosts:
     # eth5 / Port 6: fritzbox
     host__rclocal__to_merge:
       - |
-        uci set network.vlan_10.ports='eth0'           # mesh_vater_60g
+        uci set network.vlan_10.ports='eth0:u'           # mesh_vater_60g
         uci set network.vlan_20.ports='eth2:t eth4:t'  # mesh_5ghz_v
         uci set network.vlan_21.ports='eth2:t eth4:t'  # mesh_2ghz_v
         uci set network.vlan_22.ports='eth2:t eth4:t'  # mesh_5ghz_h
         uci set network.vlan_23.ports='eth2:t eth4:t'  # mesh_2ghz_h
-        uci set network.vlan_30.ports='eth1'           # mesh_lan_lte
+        uci set network.vlan_30.ports='eth1:u'           # mesh_lan_lte
         uci set network.vlan_40.ports='eth2:t eth4:t'  # dhcp public
-        uci set network.vlan_41.ports='eth5'           # dhcp fritzbox
+        uci set network.vlan_41.ports='eth5:u'           # dhcp fritzbox
         uci commit network; reload_config
 
   - hostname: baumex-vorne

--- a/locations/friedland3.yml
+++ b/locations/friedland3.yml
@@ -17,9 +17,9 @@ hosts:
     host__rclocal__to_merge:
       - |
         # untag DHCP on LAN ports
-        uci set network.vlan_40.ports='internet:t ethernet'
+        uci set network.vlan_40.ports='internet:t ethernet:u'
         # untag UPLK on WAN port
-        uci set network.vlan_50.ports='internet ethernet:t'
+        uci set network.vlan_50.ports='internet:u ethernet:t'
         uci commit network; reload_config
         # Enable legacy rates to enable meshing with neighbors
         for radio in $(uci show wireless \

--- a/locations/frischauf.yml
+++ b/locations/frischauf.yml
@@ -16,7 +16,7 @@ hosts:
     host__rclocal__to_merge:
       - |
         # untag DHCP on ports 5 and 6'
-        uci set network.vlan_40.ports='eth0:t eth1:t eth2:t eth3:t eth4 eth5'
+        uci set network.vlan_40.ports='eth0:t eth1:t eth2:t eth3:t eth4:u eth5:u'
         uci commit network; reload_config
 
   - hostname: frischauf-ap

--- a/locations/ilr.yml
+++ b/locations/ilr.yml
@@ -21,9 +21,9 @@ hosts:
     host__rclocal__to_merge:
       - |
         # untag payload traffic for AF60 to Teufelsberg
-        uci set network.vlan_10.ports='lan1:t lan2 lan3:t lan4:t lan5:t'
+        uci set network.vlan_10.ports='lan1:t lan2:u lan3:t lan4:t lan5:t'
         # untag DHCP on ports 1 and 5 for convenient maintenance'
-        uci set network.vlan_40.ports='lan1 lan2:t lan3:t lan4:t lan5'
+        uci set network.vlan_40.ports='lan1:u lan2:t lan3:t lan4:t lan5:u'
         uci commit network; reload_config
 
 snmp_devices:

--- a/locations/k9.yml
+++ b/locations/k9.yml
@@ -52,7 +52,7 @@ hosts:
         uci commit network
         reload_config
         # tag mgmt traffic on ap ports only
-        uci set network.vlan_439.ports='lan1:t lan2 lan3:t lan4 lan5:t'
+        uci set network.vlan_439.ports='lan1:t lan2:u lan3:t lan4:u lan5:t'
         # tag DHCP on all ports
         uci set network.vlan_40.ports='lan1:t lan2:t lan3:t lan4:t lan5:t'
         uci commit network; reload_config

--- a/locations/kitty.yml
+++ b/locations/kitty.yml
@@ -23,11 +23,11 @@ hosts:
     host__rclocal__to_merge:
       - |
         # untag DHCP on port 2
-        uci set network.vlan_40.ports='wan:t lan2 lan3:t lan4:t lan5:t'
+        uci set network.vlan_40.ports='wan:t lan2:u lan3:t lan4:t lan5:t'
         # untag mgmt on port 3
-        uci set network.vlan_42.ports='wan:t lan2:t lan3 lan4:t lan5:t'
+        uci set network.vlan_42.ports='wan:t lan2:t lan3:u lan4:t lan5:t'
         # untag MESH for uplink on port 1
-        uci set network.vlan_50.ports='wan lan2:t lan3:t lan4:t lan5:t'
+        uci set network.vlan_50.ports='wan:u lan2:t lan3:t lan4:t lan5:t'
         uci commit network; reload_config
 
 networks:

--- a/locations/rigaer78.yml
+++ b/locations/rigaer78.yml
@@ -56,7 +56,7 @@ hosts:
     host__rclocal__to_merge:
       - |
         # Untag DHCP on some ports
-        uci set network.vlan_40.ports='lan1:t lan2 lan3 lan4 wan'
+        uci set network.vlan_40.ports='lan1:t lan2:u lan3:u lan4:u wan:u'
         uci commit network; reload_config
 
   - hostname: rigaer78-back-floor-3-left
@@ -78,7 +78,7 @@ hosts:
     host__rclocal__to_merge:
       - |
         # Untag DHCP on some ports
-        uci set network.vlan_40.ports='lan1:t lan2 lan3 lan4'
+        uci set network.vlan_40.ports='lan1:t lan2:u lan3:u lan4:u'
         uci commit network; reload_config
 
   - hostname: rigaer78-east-2ghz

--- a/locations/sav.yml
+++ b/locations/sav.yml
@@ -23,11 +23,11 @@ hosts:
     host__rclocal__to_merge:
       - |
         # untag payload traffic for Wave to Emma
-        uci set network.vlan_10.ports='wan lan2:t lan3:t lan4:t lan5:t'
+        uci set network.vlan_10.ports='wan:u lan2:t lan3:t lan4:t lan5:t'
         # untag DHCP on port 2
-        uci set network.vlan_40.ports='wan:t lan2 lan3:t lan4:t lan5:t'
+        uci set network.vlan_40.ports='wan:t lan2:u lan3:t lan4:t lan5:t'
         # untag port 3 for local backup uplink
-        uci set network.vlan_50.ports='wan:t lan2:t lan3 lan4:t lan5:t'
+        uci set network.vlan_50.ports='wan:t lan2:t lan3:u lan4:t lan5:t'
         uci commit network; reload_config
 
 snmp_devices:


### PR DESCRIPTION
Replace untagged ports with ":u" syntax by running: find ./ -type f -exec perl -i -pe 's/\b(eth\d+|lan\d+|wan|internet|ethernet)\b(?!:t|:u)/\1:u/g if /uci set/' {} +