### PR TITLE
zwingli: upgrade to 24.10

### DIFF
--- a/locations/zwingli.yml
+++ b/locations/zwingli.yml
@@ -12,6 +12,7 @@ hosts:
     model: "linksys_e8450-ubi"
     wireless_profile: freifunk_default
     wifi_roaming: true
+    openwrt_version: 24.10-SNAPSHOT
     # USBIP packages to manage Meshtastic node (TLORA_V2_1_1P6) connected via USB
     host__packages__to_merge:
       - "kmod-usb-ohci usbip-server usbip-client"


### PR DESCRIPTION
I prepared a Belkin RT3200 replacement with 24.10. Once installed this PR can be merged.