### PR TITLE
templates: network: fix meshing with Bird on core routers

### DIFF
--- a/roles/cfg_openwrt/templates/libraries/network.j2
+++ b/roles/cfg_openwrt/templates/libraries/network.j2
@@ -7,7 +7,7 @@
     {% set ifname = "" %}
     {% if isBridgeNeeded(network) | from_json %}
         {% set ifname = getBridgeIfname(network) %}
-    {% elif int_port is defined and network.get('mesh_ap') == inventory_hostname %}
+    {% elif (int_port is defined or role == 'corerouter') and network.get('mesh_ap') == inventory_hostname %}
         {% set ifname = libwireless.getLocalAdhocIfnameByNetwork(network) %}
     {% else %}
         {% set ifname = getPortIfname(network) %}


### PR DESCRIPTION
Running 802.11s mesh directly on a core router caused OLSR to handle meshing because the Bird configuration was incorrect. This patch fixes the issue by checking for core routers in the library functions and selecting the interface name accordingly.

Fixes: 7f523e8f9934 ("templates: fix roaming bug by avoiding bridge in DSA setups")