### PR TITLE
model: use 24.10 instead of snapshot for cudy models

### DIFF
--- a/group_vars/model_cudy_ap3000_v1.yml
+++ b/group_vars/model_cudy_ap3000_v1.yml
@@ -1,6 +1,5 @@
 ---
 target: mediatek/filogic
-openwrt_version: snapshot
 brand_nice: Cudy
 model_nice: AP3000
 version_nice: v1

--- a/group_vars/model_cudy_ap3000outdoor_v1.yml
+++ b/group_vars/model_cudy_ap3000outdoor_v1.yml
@@ -1,6 +1,5 @@
 ---
 target: mediatek/filogic
-openwrt_version: snapshot
 brand_nice: Cudy
 model_nice: AP3000 Outdoor
 version_nice: v1

--- a/group_vars/model_cudy_wr3000h_v1.yml
+++ b/group_vars/model_cudy_wr3000h_v1.yml
@@ -4,8 +4,6 @@ brand_nice: Cudy
 model_nice: WR3000H
 version_nice: v1
 
-openwrt_version: snapshot
-
 dsa_ports:
   - wan
   - lan1


### PR DESCRIPTION
The Cudy models are supported in 24.10 for some time now. This PR switches the models from snapshot to 24.10 for more stable builds. Users can keep using snapshot for individual locations by specifying it in the location yml file.