### PR TITLE
adblock-lean: add as alternative ad-blocking provider to adblock-fast

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -421,6 +421,17 @@ By default this installs [`qos-scripts`](https://github.com/openwrt/packages/tre
     qosify_overhead_type: pppoe-llcsnap   # optional, defaults to 'none' - see qosify's overhead_type
 ```
 
+### ad blocking
+
+Corerouters can run DNS-based ad blocking via dnsmasq. It's off by default (`adblock_enabled: false`); enable it per location:
+
+```yml
+adblock_enabled: true
+adblock_provider: lean   # 'fast' (default) or 'lean'
+```
+
+`fast` (default) uses [`adblock-fast`](https://github.com/openwrt/packages/tree/master/net/adblock-fast) from the upstream `packages` feed, tunable via `adblock_fast_*` variables. `lean` uses [`adblock-lean`](https://github.com/lynxthecat/adblock-lean) instead, tunable via `adblock_lean_*` variables (see `group_vars/role_corerouter/general.yml`) - only available via the `falter` feed, not upstream OpenWrt.
+
 ### ssh-keys
 
 By default the ssh-keys within `all/ssh-keys.yml` will be installed on all hosts. To add additional ssh keys use this format:

--- a/group_vars/role_corerouter/general.yml
+++ b/group_vars/role_corerouter/general.yml
@@ -3,6 +3,7 @@
 wireless_profile: disable
 
 adblock_enabled: false
+adblock_provider: fast
 adblock_fast_dns: dnsmasq.servers
 adblock_fast_force_dns: false
 adblock_fast_gateway_check: none
@@ -15,6 +16,19 @@ adblock_fast_feeds:
     url: https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/combined_disguised_trackers_justdomains.txt
   - name: CERT Polska Dangerous Websites
     url: https://hole.cert.pl/domains/v2/domains.txt
+
+adblock_lean_raw_block_lists: []
+adblock_lean_dnsmasq_block_lists:
+  - https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/dnsmasq/pro.txt
+adblock_lean_dnsmasq_indexes: "0"
+# "cfg01411c" is UCI's auto-generated section ID for dhcp.j2's dnsmasq block - not
+# controlled by this project, and will silently go stale if that block ever moves.
+adblock_lean_dnsmasq_conf_dirs: "/tmp/dnsmasq.cfg01411c.d"
+adblock_lean_min_good_line_count: 180000
+adblock_lean_max_file_part_size_kb: 20000
+adblock_lean_max_blocklist_file_size_kb: 32768
+adblock_lean_boot_start_delay_s: 180
+adblock_lean_cron_schedule: "17 5 * * *"
 
 role_corerouter__sysctl__to_merge:
   net.netfilter.nf_conntrack_max: 131072

--- a/roles/cfg_openwrt/tasks/add_symlinks.yml
+++ b/roles/cfg_openwrt/tasks/add_symlinks.yml
@@ -19,3 +19,29 @@
     state: link
   when:
     - (sysfs_overrides | default([]) | length > 0) or (cpu_governor is defined)
+
+# Symlink directly instead of `service adblock-lean enable`: that shell function also
+# writes a cron entry itself, which would fight crontabs/root.j2's declarative rendering.
+- name: Enable adblock-lean start symlink
+  file:
+    src: "../init.d/adblock-lean"
+    dest: "{{ configs_dir }}/etc/rc.d/S99adblock-lean"
+    state: link
+    force: true
+    follow: false
+  when:
+    - role == "corerouter"
+    - adblock_enabled | default(false) | bool
+    - adblock_provider | default('fast') == 'lean'
+
+- name: Enable adblock-lean stop symlink
+  file:
+    src: "../init.d/adblock-lean"
+    dest: "{{ configs_dir }}/etc/rc.d/K04adblock-lean"
+    state: link
+    force: true
+    follow: false
+  when:
+    - role == "corerouter"
+    - adblock_enabled | default(false) | bool
+    - adblock_provider | default('fast') == 'lean'

--- a/roles/cfg_openwrt/tasks/conditional_packages.yml
+++ b/roles/cfg_openwrt/tasks/conditional_packages.yml
@@ -54,6 +54,15 @@
   when:
     - role == 'corerouter'
     - adblock_enabled | default(false) | bool
+    - adblock_provider | default('fast') == 'fast'
+
+- name: "Add adblock-lean support on core-routers"
+  set_fact:
+    packages: "{{ packages + ['-adblock-fast', '-luci-app-adblock-fast', 'adblock-lean'] }}"
+  when:
+    - role == 'corerouter'
+    - adblock_enabled | default(false) | bool
+    - adblock_provider | default('fast') == 'lean'
 
 - name: "Remove or replace packages on low mem and low flash"
   set_fact:

--- a/roles/cfg_openwrt/templates/corerouter/adblock-lean/config.j2
+++ b/roles/cfg_openwrt/templates/corerouter/adblock-lean/config.j2
@@ -1,0 +1,53 @@
+{% if adblock_enabled | default(false) | bool and adblock_provider | default('fast') == 'lean' %}
+{# config_format must match adblock-lean's own CONFIG_FORMAT (get_config_format() in its init
+   script) or it fails closed at load time instead of applying stale config - keep in sync when
+   bumping the adblock-lean package version. #}
+# config_format=v11
+
+whitelist_mode="0"
+
+raw_block_lists="{{ adblock_lean_raw_block_lists | default([]) | join(' ') }}"
+raw_allow_lists=""
+raw_ipv4_block_lists=""
+
+dnsmasq_block_lists="{{ adblock_lean_dnsmasq_block_lists | default([]) | join(' ') }}"
+dnsmasq_allow_lists=""
+dnsmasq_ipv4_block_lists=""
+
+hosts_block_lists=""
+
+local_allowlist_path="/etc/adblock-lean/allowlist"
+local_blocklist_path="/etc/adblock-lean/blocklist"
+
+test_domains="google.com microsoft.com amazon.com matrix.org github.com downloads.openwrt.org berlin.freifunk.net"
+
+list_part_failed_action="STOP"
+max_download_retries="3"
+
+hagezi_default_mirror="github"
+oisd_default_mirror="oisd"
+stevenblack_default_mirror="github"
+
+min_good_line_count="{{ adblock_lean_min_good_line_count }}"
+min_blocklist_part_line_count="1"
+min_ipv4_blocklist_part_line_count="1"
+min_allowlist_part_line_count="1"
+max_file_part_size_KB="{{ adblock_lean_max_file_part_size_kb }}"
+max_blocklist_file_size_KB="{{ adblock_lean_max_blocklist_file_size_kb }}"
+
+deduplication="1"
+
+compression_util="gzip"
+intermediate_compression_options="-3"
+final_compression_options="-6"
+unload_blocklist_before_update="auto"
+
+boot_start_delay_s="{{ adblock_lean_boot_start_delay_s }}"
+MAX_PARALLEL_JOBS="auto"
+
+custom_script=""
+cron_schedule="{{ adblock_lean_cron_schedule }}"
+
+DNSMASQ_INDEXES="{{ adblock_lean_dnsmasq_indexes }}"
+DNSMASQ_CONF_DIRS="{{ adblock_lean_dnsmasq_conf_dirs }}"
+{% endif %}

--- a/roles/cfg_openwrt/templates/corerouter/config/adblock-fast.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/adblock-fast.j2
@@ -1,6 +1,6 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
 config adblock-fast 'config'
-	option enabled '{{ 1 if adblock_enabled | default(false) | bool else 0 }}'
+	option enabled '{{ 1 if adblock_enabled | default(false) | bool and adblock_provider | default('fast') == 'fast' else 0 }}'
 	option dns '{{ adblock_fast_dns }}'
 	list dnsmasq_instance '*'
 	option force_dns '{{ 1 if adblock_fast_force_dns | default(false) | bool else 0 }}'

--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -20,6 +20,10 @@ config dnsmasq
 {% for _dns_server in dns_servers %}
         list server '{{ _dns_server }}'
 {% endfor %}
+{% if adblock_enabled | default(false) | bool and adblock_provider | default('fast') == 'lean' %}
+	list addnmount '/bin/busybox'
+	list addnmount '/var/run/adblock-lean/abl-blocklist.gz'
+{% endif %}
 
 {% for network in networks | selectattr('role', 'equalto', 'mgmt') %}
   {% for host, ip_num in network['assignments'].items() %}

--- a/roles/cfg_openwrt/templates/corerouter/crontabs/root.j2
+++ b/roles/cfg_openwrt/templates/corerouter/crontabs/root.j2
@@ -1,0 +1,3 @@
+{% if adblock_enabled | default(false) | bool and adblock_provider | default('fast') == 'lean' and adblock_lean_cron_schedule | default('disable') != 'disable' %}
+{{ adblock_lean_cron_schedule }} /etc/init.d/adblock-lean start
+{% endif %}


### PR DESCRIPTION
Add adblock-lean/config.j2, rc.d start/stop symlinks, and a cron schedule, gated by adblock_provider: lean (default remains 'fast'). The package itself comes from the Falter feed - this only manages site policy: /etc/adblock-lean/config content, dnsmasq addnmount integration for the generated blocklist, and enablement. Mutually exclusive with adblock-fast via the adblock_provider guard added to both packaging tasks and adblock-fast.j2's 'enabled' option.