### PR TITLE
dhcp: prevent hour-long .ff record unavailability

### DIFF
--- a/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
+++ b/roles/cfg_openwrt/templates/corerouter/config/dhcp.j2
@@ -6,6 +6,7 @@ config dnsmasq
 	option rebind_protection '1'
 	option rebind_localhost '1'
 	option local '/lan/'
+	option local_ttl '300'
 	option domain 'ff'
 	option expandhosts '1'
 	option authoritative '1'
@@ -14,15 +15,16 @@ config dnsmasq
 	option noping '{{ dhcp_no_ping|int if dhcp_no_ping is defined else 1 }}'
 	option quietdhcp '1'
 	option cachesize '{{ dns_cache_size | default(10000) }}'
- 	list server '/olsr/'
+	list server '/olsr/'
+	list server '/ff/'
 {% for _dns_server in dns_servers %}
         list server '{{ _dns_server }}'
 {% endfor %}
 
 {% for network in networks | selectattr('role', 'equalto', 'mgmt') %}
   {% for host, ip_num in network['assignments'].items() %}
-config domain '{{ host | replace('-', '_') }}_olsr'
-	option name '{{ host }}.olsr'
+config domain '{{ host | replace('-', '_') }}_ff'
+	option name '{{ host }}.ff'
 	option ip '{{ network['prefix'] | ansible.utils.ipaddr(ip_num) | ansible.utils.ipaddr('address') }}'
 
   {% endfor %}


### PR DESCRIPTION
Two issues being fixed here, which together are really annoying.

Dnsmasq uses a TTL of 0 for locally configured records by default. That means when a node disappears from bgpdisco just briefly, the rest of the network immediately loses its domain records.

If a requested domain record isn't found locally,
dnsmasq forwards it to one of the configured upstream resolvers. We want to never cache their high-TTL NXDOMAIN responses. We forgot to update this option for the new .ff domain though.

When combined, these two issues resulted in individual domain records becoming unavailable for up to an hour (depending on the upstream).

The fixes:
- Set a low 5 minute TTL for .ff records to let clients cache them.
- Prevent .ff requests from being forwarded to upstreams.

We also keep the old .olsr TLD server option, for now. It's still quite possible that .olsr requests come in.