### PR TITLE
ansible: prevent false-positive warnings + update dependencies

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,7 @@ inventory = inventory/base_inventory, inventory/keyed_groups_stage_1.config, inv
 interpreter_python = auto_silent
 stdout_callback = debug
 callbacks_enabled = ansible.posix.profile_tasks, ansible.posix.timer
+inject_facts_as_vars = False
 
 #needed for software upgrade
 [persistent_connection]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-ansible == 14.2.0
-ansible-lint == 26.6.0
+ansible == 14.3.1
+ansible-lint == 26.8.0
 jmespath == 1.1.0
 netaddr == 1.3.0
-python-dotenv == 1.2.2
+python-dotenv == 1.2.3
 requests == 2.34.2
 yamllint == 1.38.0
 yq == 4.1.2


### PR DESCRIPTION
Two things: update our dependencies, and:

We recently started getting the following deprecation warning:

    [DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated,
    top-level facts will not be auto injected after the change.
    This feature will be removed from ansible-core version 2.24.

    Origin: /home/user/w/ff/bbb-configs/roles/cfg_openwrt/tasks/main.yml:40:14

    Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.

In our case, this warning is false positive.
It looks like we don't make use of injected fact variables.
We can disable INJECT_FACTS_AS_VARS without anything breaking.