### PR TITLE
zorrow-core, hausbuch-core: bump to openwrt 25.12

### DIFF
--- a/locations/hausbuch.yml
+++ b/locations/hausbuch.yml
@@ -11,7 +11,6 @@ hosts:
   - hostname: hausbuch-core
     role: corerouter
     model: "x86-64"
-    openwrt_version: 24.10-SNAPSHOT
     image_search_pattern: "*-ext4-combined.img*"
     host__packages__to_merge:
       - qemu-ga

--- a/locations/zorrow.yml
+++ b/locations/zorrow.yml
@@ -11,7 +11,6 @@ hosts:
   - hostname: zorrow-core
     role: corerouter
     model: "x86-64"
-    openwrt_version: 24.10-SNAPSHOT
     image_search_pattern: "*-ext4-combined.img*"
     host__packages__to_merge:
       - qemu-ga


### PR DESCRIPTION
removed override of the openwrt_version in the location files