### PR TITLE
imageprofile: use owm-ucode only for OpenWrt 25.12+ and owmsh for older OpenWRT versions

### DIFF
--- a/group_vars/role_corerouter/imageprofile.yml
+++ b/group_vars/role_corerouter/imageprofile.yml
@@ -12,7 +12,6 @@ role_corerouter__packages__to_merge:
   - luci-app-olsr
   - luci-app-olsr-services
   - luci-mod-falter
-  - falter-berlin-owm-ucode
   - iptables-mod-ipopt
   - kmod-ipt-ipopt
 
@@ -25,3 +24,6 @@ collectd__packages__to_merge:
 bird__packages__to_merge:
   - bird3-babelpatch
   - bird3c
+
+owm__packages__to_merge:
+  - falter-berlin-owm-ucode

--- a/group_vars/role_gateway/imageprofile.yml
+++ b/group_vars/role_gateway/imageprofile.yml
@@ -11,7 +11,6 @@ role_uplink_gw__packages__to_merge:
   - luci-app-olsr
   - luci-app-olsr-services
   - luci-mod-falter
-  - falter-berlin-owm-ucode
   - falter-berlin-gw
   - iptables-mod-ipopt
   - kmod-ipt-ipopt
@@ -29,6 +28,9 @@ role_uplink_gw__packages__to_merge:
 bird__packages__to_merge:
   - bird3-babelpatch
   - bird3c
+
+owm__packages__to_merge:
+  - falter-berlin-owm-ucode
 
 collectd__packages__to_merge:
   - collectd-mod-conntrack

--- a/group_vars/version_23_05_6.yml
+++ b/group_vars/version_23_05_6.yml
@@ -7,3 +7,6 @@ uses_opkg: true
 bird__packages__to_merge:
   - bird2-babelpatch
   - bird2c
+
+owm__packages__to_merge:
+  - falter-berlin-owmsh

--- a/group_vars/version_24_10_snapshot.yml
+++ b/group_vars/version_24_10_snapshot.yml
@@ -1,3 +1,6 @@
 ---
 feed_version: 1.5.0-snapshot
 uses_opkg: true
+
+owm__packages__to_merge:
+  - falter-berlin-owmsh


### PR DESCRIPTION
The owm-ucode rewrite of owmsh uses functionality which is only available in OpenWrt 25.12+. It does not really make much sense to add a compatibility layer in the package therefore we should use the old owmsh package for older OpenWrt versions.

fixes https://github.com/freifunk-berlin/bbb-configs/issues/1739